### PR TITLE
MyPage CSS를 구현한다.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ const App = () => {
         <Route path="/FindUser" element={<FindUser />} />
         <Route path="/MyPage" element={<MyPage />} />
         <Route path="/Notice" element={<Notice />} />
+        <Route path="/QnAPosting" element={<QnAPosting />} />
         <Route path="/DevTerminal" element={<DevTerminal />} />
         <Route path="/DevMockingApi" element={<DevMockingApi />} />
         <Route path="/DevNotation" element={<DevNotation />} />

--- a/src/Page/MyPage/components/MyPage.BookMark.component.jsx
+++ b/src/Page/MyPage/components/MyPage.BookMark.component.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const MyPageBookMark = () => {
+  return (
+    <div>
+      <div>MyPageBookMark</div>
+    </div>
+  );
+};
+
+export default MyPageBookMark;

--- a/src/Page/MyPage/components/MyPage.Comment.component.jsx
+++ b/src/Page/MyPage/components/MyPage.Comment.component.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const MyPageComment = () => {
+  return (
+    <div>
+      <div>MyPageComment</div>
+    </div>
+  );
+};
+
+export default MyPageComment;

--- a/src/Page/MyPage/components/MyPage.Posting.component.jsx
+++ b/src/Page/MyPage/components/MyPage.Posting.component.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const MyPagePosting = () => {
+  return (
+    <div>
+      <div>MyPagePosting</div>
+    </div>
+  );
+};
+
+export default MyPagePosting;

--- a/src/Page/MyPage/components/MyPage.Result.component.jsx
+++ b/src/Page/MyPage/components/MyPage.Result.component.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const MyPageResult = () => {
+  return (
+    <div>
+      <div>MyPageResult</div>
+    </div>
+  );
+};
+
+export default MyPageResult;

--- a/src/Page/MyPage/components/MyPage.jsx
+++ b/src/Page/MyPage/components/MyPage.jsx
@@ -1,22 +1,18 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import '../css/MyPage.scss';
+import Header from '../../Header/components/Header';
+import Footer from '../../Footer/components/Footer';
 
 const MyPage = () => {
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        marginTop: '40vh',
-        border: '1px solid black',
-      }}
-    >
-      <h1>네편 프로젝트 with 멋사</h1>
-      <h3>현재 페이지 파일 이름은 MyPage.jsx 입니다.</h3>
-      <Link to="/DevTerminal">
-        <button>개발 터미널로 이동</button>
-      </Link>
+    <div>
+      <Header />
+      <div>
+        <div>개인정보 프로필</div>
+        <div>스위치 버튼 Header와 같은 스타일 참조</div>
+        <div>contents 변경 컴포넌트</div>
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/Page/MyPage/components/MyPage.jsx
+++ b/src/Page/MyPage/components/MyPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+// import useGlobalState from '../../../Global/Hooks/useGlobalState';
 import '../css/MyPage.scss';
 import MyPageBookMark from './MyPage.BookMark.component';
 import MyPagePosting from './MyPage.Posting.component';
@@ -8,7 +9,6 @@ import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 
 const MyPage = () => {
-  // 이 부분을 contextAPI를 통해서 true false를 통해서 동작할 수 있게 구현 할 예정
   const [isContentState, setContentState] = useState(false);
   const [isContent, setContent] = useState({
     myResult: true,
@@ -32,14 +32,6 @@ const MyPage = () => {
     if (isContent.myPosting) return <MyPagePosting />;
     if (isContent.myComment) return <MyPageComment />;
     if (isContent.myBookMark) return <MyPageBookMark />;
-    return <div>선택한 항목이 없습니다.</div>;
-  };
-
-  const handleContentMessage = () => {
-    if (isContent.myResult) return '결과지가';
-    if (isContent.myPosting) return '질문이';
-    if (isContent.myComment) return '답변이';
-    if (isContent.myBookMark) return '북마크가';
     return <div>선택한 항목이 없습니다.</div>;
   };
 
@@ -110,13 +102,7 @@ const MyPage = () => {
             책갈피
           </div>
         </div>
-        {isContentState ? (
-          <div className="MyPage-contents">{renderContent()}</div>
-        ) : (
-          <div className="MyPage-none-contents">
-            작성한 {handleContentMessage()} 없습니다.
-          </div>
-        )}
+        <div className="MyPage-contents">{renderContent()}</div>
         {/* 페이지 네이션은 각 컴폰넌트 내부로 들어갈 예정이다. */}
         <div className="MyPage-pagenation">
           {isContentState ? '페이지 네이션' : ''}

--- a/src/Page/MyPage/components/MyPage.jsx
+++ b/src/Page/MyPage/components/MyPage.jsx
@@ -1,9 +1,14 @@
 import React, { useState } from 'react';
 import '../css/MyPage.scss';
+import MyPageBookMark from './MyPage.BookMark.component';
+import MyPagePosting from './MyPage.Posting.component';
+import MyPageComment from './MyPage.Comment.component';
+import MyPageResult from './MyPage.Result.component';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 
 const MyPage = () => {
+  // 이 부분을 contextAPI를 통해서 true false를 통해서 동작할 수 있게 구현 할 예정
   const [isContentState, setContentState] = useState(false);
   const [isContent, setContent] = useState({
     myResult: true,
@@ -20,6 +25,22 @@ const MyPage = () => {
       myComment: contentType === 'myComment',
       myBookMark: contentType === 'myBookMark',
     }));
+  };
+
+  const renderContent = () => {
+    if (isContent.myResult) return <MyPageResult />;
+    if (isContent.myPosting) return <MyPagePosting />;
+    if (isContent.myComment) return <MyPageComment />;
+    if (isContent.myBookMark) return <MyPageBookMark />;
+    return <div>선택한 항목이 없습니다.</div>;
+  };
+
+  const handleContentMessage = () => {
+    if (isContent.myResult) return '결과지가';
+    if (isContent.myPosting) return '질문이';
+    if (isContent.myComment) return '답변이';
+    if (isContent.myBookMark) return '북마크가';
+    return <div>선택한 항목이 없습니다.</div>;
   };
 
   return (
@@ -90,11 +111,10 @@ const MyPage = () => {
           </div>
         </div>
         {isContentState ? (
-          <div className="MyPage-contents">contents 변경 컴포넌트</div>
+          <div className="MyPage-contents">{renderContent()}</div>
         ) : (
-          // 해당 부분 질문 부분에 동적으로 변경이 가능하도록 구현해야한다.
           <div className="MyPage-none-contents">
-            작성한 질문(글)이 없습니다.
+            작성한 {handleContentMessage()} 없습니다.
           </div>
         )}
         {/* 페이지 네이션은 각 컴폰넌트 내부로 들어갈 예정이다. */}

--- a/src/Page/MyPage/components/MyPage.jsx
+++ b/src/Page/MyPage/components/MyPage.jsx
@@ -1,9 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import '../css/MyPage.scss';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 
 const MyPage = () => {
+  const [isContentState, setContentState] = useState(false);
+  const [isContent, setContent] = useState({
+    myResult: true,
+    myPosting: false,
+    myComment: false,
+    myBookMark: false,
+  });
+
+  const handleContent = contentType => {
+    setContent(prev => ({
+      ...prev,
+      myResult: contentType === 'myResult',
+      myPosting: contentType === 'myPosting',
+      myComment: contentType === 'myComment',
+      myBookMark: contentType === 'myBookMark',
+    }));
+  };
+
   return (
     <div className="MyPage">
       <Header />
@@ -26,13 +44,63 @@ const MyPage = () => {
           </div>
         </div>
         <div className="MyPage-switch">
-          <div id="">내 결과지</div>
-          <div id="">내 게시글</div>
-          <div id="">내 답변</div>
-          <div id="">책갈피</div>
+          <div
+            id={isContent.myResult ? 'MyPage-switched' : ''}
+            onKeyDown={() => {}}
+            onClick={() => {
+              handleContent('myResult');
+            }}
+            tabIndex="0"
+            role="button"
+          >
+            내 결과지
+          </div>
+          <div
+            id={isContent.myPosting ? 'MyPage-switched' : ''}
+            onKeyDown={() => {}}
+            onClick={() => {
+              handleContent('myPosting');
+            }}
+            tabIndex="0"
+            role="button"
+          >
+            내 게시글
+          </div>
+          <div
+            id={isContent.myComment ? 'MyPage-switched' : ''}
+            onKeyDown={() => {}}
+            onClick={() => {
+              handleContent('myComment');
+            }}
+            tabIndex="0"
+            role="button"
+          >
+            내 답변
+          </div>
+          <div
+            id={isContent.myBookMark ? 'MyPage-switched' : ''}
+            onKeyDown={() => {}}
+            onClick={() => {
+              handleContent('myBookMark');
+            }}
+            tabIndex="0"
+            role="button"
+          >
+            책갈피
+          </div>
         </div>
-        <div className="MyPage-contents">contents 변경 컴포넌트</div>
-        <div className="MyPage-pagenation">페이지 네이션</div>
+        {isContentState ? (
+          <div className="MyPage-contents">contents 변경 컴포넌트</div>
+        ) : (
+          // 해당 부분 질문 부분에 동적으로 변경이 가능하도록 구현해야한다.
+          <div className="MyPage-none-contents">
+            작성한 질문(글)이 없습니다.
+          </div>
+        )}
+        {/* 페이지 네이션은 각 컴폰넌트 내부로 들어갈 예정이다. */}
+        <div className="MyPage-pagenation">
+          {isContentState ? '페이지 네이션' : ''}
+        </div>
       </div>
       <Footer />
     </div>

--- a/src/Page/MyPage/components/MyPage.jsx
+++ b/src/Page/MyPage/components/MyPage.jsx
@@ -5,12 +5,34 @@ import Footer from '../../Footer/components/Footer';
 
 const MyPage = () => {
   return (
-    <div>
+    <div className="MyPage">
       <Header />
-      <div>
-        <div>개인정보 프로필</div>
-        <div>스위치 버튼 Header와 같은 스타일 참조</div>
-        <div>contents 변경 컴포넌트</div>
+      <div className="MyPage-container">
+        <div className="MyPage-profile">
+          <div id="MyPage-nickname">사용자 닉네임</div>
+          <div className="MyPage-current">
+            <div id="MyPage-posting">
+              <span>내 개시글</span>
+              <span>999개</span>
+            </div>
+            <div id="MyPage-question">
+              <span>내 질문</span>
+              <span>999개</span>
+            </div>
+            <div id="MyPage-comment">
+              <span>내 답변</span>
+              <span>999개</span>
+            </div>
+          </div>
+        </div>
+        <div className="MyPage-switch">
+          <div id="">내 결과지</div>
+          <div id="">내 게시글</div>
+          <div id="">내 답변</div>
+          <div id="">책갈피</div>
+        </div>
+        <div className="MyPage-contents">contents 변경 컴포넌트</div>
+        <div className="MyPage-pagenation">페이지 네이션</div>
       </div>
       <Footer />
     </div>

--- a/src/Page/MyPage/css/MyPage.scss
+++ b/src/Page/MyPage/css/MyPage.scss
@@ -1,0 +1,89 @@
+.MyPage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100vh;
+  font-family: Pretendard;
+
+  .MyPage-container {
+    // background-color: aqua;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 109px;
+    margin-bottom: 120px;
+    width: 980px;
+    // padding: 109px 470px 120px 470px;
+
+    .MyPage-profile {
+      // background-color: wheat;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      width: 100%;
+      margin-bottom: 138px;
+
+      #MyPage-nickname {
+        font-size: 22px;
+        font-weight: 600;
+        line-height: 30px;
+        letter-spacing: -0.025em;
+        text-underline-position: from-font;
+        text-decoration-skip-ink: none;
+        margin-bottom: 13px;
+      }
+
+      .MyPage-current {
+        display: flex;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 22px;
+        text-underline-position: from-font;
+        text-decoration-skip-ink: none;
+        color: #333333;
+
+        #MyPage-posting span:last-child,
+        #MyPage-question span:last-child,
+        #MyPage-comment span:last-child {
+          font-size: 14px;
+          font-weight: 400;
+          line-height: 22px;
+          text-underline-position: from-font;
+          text-decoration-skip-ink: none;
+          margin-left: 8px;
+          margin-right: 18px;
+          color: #111111;
+        }
+      }
+    }
+
+    .MyPage-switch {
+      display: flex;
+      justify-content: flex-start;
+      width: 100%;
+      height: 37px;
+      gap: 38px;
+    }
+
+    .MyPage-switch div:hover {
+      color: #204598;
+      border-bottom: 1px solid #204598;
+      cursor: pointer;
+    }
+
+    #MyPage-switched {
+      color: #204598;
+      border-bottom: 1px solid #204598;
+    }
+
+    .MyPage-contents {
+      margin-top: 70px;
+      margin-bottom: 40px;
+    }
+
+    .MyPage-pagenation {}
+  }
+}

--- a/src/Page/MyPage/css/MyPage.scss
+++ b/src/Page/MyPage/css/MyPage.scss
@@ -80,8 +80,16 @@
     }
 
     .MyPage-contents {
+      display: flex;
+      justify-content: center;
+      width: 100%;
       margin-top: 70px;
       margin-bottom: 40px;
+    }
+
+    .MyPage-none-contents {
+      margin-top: 200px;
+      margin-bottom: 400px;
     }
 
     .MyPage-pagenation {}


### PR DESCRIPTION
## #️⃣ Issue Number
- close #81 

## ✏️Task
- [x] MyPage CSS를 구현한다.
  - [x] content 영역 선택시 동적으로 선택된 밑줄 표기 구현 완료

## ✏️Tasks Description
- MyPage 작업을 함에 있어서 어려움은 없었다. 다만, MyPage에서 contents영역을 불러들일 때, useFetchAPI의 상태에 따라 값을 불러들이고 예외를 처리하기 위해서 contextAPI를 사용해서 전역 상태로 값을 외부 컴포넌트(MyPage.jsx), 내부 컴포넌트(MyPage.~.component.jsx)에서 useEffect로 초기화 하면서 동기화하는 방식으로 구현을 하려고 했다. 하지만 이 방법에 매우 크나큰 허점이 있었다. useEffect로 초기화 하면서 동기화를 내부 컴포넌트에서 동작하게 하려면 애초에 내부 컴포넌트를 렌더링해야 useEffect가 동작한다는 것을 망각했다. 즉, 예외의 처리를 각 컴포넌트 내부에서 동작하게 했어야한다. 이해를 돕기 위해서 예시 코드는 다음과 같다.
  ```
  import useGloabalState from '../../../'Global/Hooks/useGlobalState';
  const MyPage = ( ) => { 
  const { isMyPageState, setMyPageState } = useGlobalsState();  // isMyPageState는 기본 false로 구성 했다.
  
    return(
      { 
        isMyPageState ? 
          ( <MyPagePosting / > ) : ( <div>작성된 게시글이 없습니다.</div> )
      }
    )};
  ```
  이렇게 애초에 isMyPageState가 false로 구성이 되어 있어서 원하는 컴포넌트가 렌더링 되지 않아 해당 컴포넌트의 useEffect는 동작하지 않고 MyPage 컴포넌트에서 아무리 isMyPageState를 동기화 하려고 해도 여전히 false로 인지하고 jsx에서 설정한 삼항연산 또한 예상한 대로 동작하지 않게 된다.
- 그렇게 완성 된 페이지의 모습은 다음과 같다.
![Mypage-test](https://github.com/user-attachments/assets/1e387189-ac17-4332-abdd-741b4c8dbc12)

- 추후 상세 contents 영역은 모든 페이지가 완료되고 추후에 점검을 통해 확인해볼 예정이다.

- useGlobalState를 사용할 때 contextAPI로 구성한 훅의 반환 값이 객체로 설정되어 있기 때문에 일반적인 useState 정의 방식과는 조금은 차이가 있다는 점을 주의할 필요가 있다.
 
### 🗓Next Task
- 
