### PR TITLE
내 근로 정리 (WorkArrangement) 페이지 컴포넌트 분리와 API를 연결한다.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import ContractReview from './Page/ContractReview/components/ContractReview';
 import QuestionAndAnswer from './Page/QuestionAndAnswer/components/QuestionAndAnswer';
 import ViewQuestionAndAnswer from './Page/QuestionAndAnswer/components/ViewQuestionAndAnswer';
 import WorkArrangement from './Page/WorkArrangement/components/WorkArrangement';
+import WorkArrangementList from './Page/WorkArrangement/components/WorkArrangementList';
 import ViewMyWork from './Page/WorkArrangement/components/ViewMyWork';
 import ViewMyWorkResult from './Page/WorkArrangement/components/ViewMyWorkResult';
 import ViewMyWorkResultCalculate from './Page/WorkArrangement/components/ViewMyWorkResultCalculate';
@@ -39,6 +40,7 @@ const App = () => {
           element={<ViewQuestionAndAnswer />}
         />
         <Route path="/WorkArrangement" element={<WorkArrangement />} />
+        <Route path="/WorkArrangement/List" element={<WorkArrangementList />} />
         <Route path="/ViewMyWork" element={<ViewMyWork />} />
         <Route
           path="/ViewMyWorkResult/:worksheetId"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,7 @@ const App = () => {
         />
         <Route path="/WorkArrangement" element={<WorkArrangement />} />
         <Route path="/ViewMyWork" element={<ViewMyWork />} />
-        <Route path="/ViewMyWorkResult" element={<ViewMyWorkResult />} />
+        <Route path="/ViewMyWorkResult/:id" element={<ViewMyWorkResult />} />
         <Route path="/Login" element={<Login />} />
         <Route path="/SignUp" element={<SignUp />} />
         <Route path="/MyPage" element={<MyPage />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import ViewQuestionAndAnswer from './Page/QuestionAndAnswer/components/ViewQuest
 import WorkArrangement from './Page/WorkArrangement/components/WorkArrangement';
 import ViewMyWork from './Page/WorkArrangement/components/ViewMyWork';
 import ViewMyWorkResult from './Page/WorkArrangement/components/ViewMyWorkResult';
+import ViewMyWorkResultCalculate from './Page/WorkArrangement/components/ViewMyWorkResultCalculate';
 import Login from './Page/Login/components/Login';
 import SignUp from './Page/Login/SignUp/components/SignUp';
 import MyPage from './Page/MyPage/components/MyPage';
@@ -42,6 +43,10 @@ const App = () => {
         <Route
           path="/ViewMyWorkResult/:worksheetId"
           element={<ViewMyWorkResult />}
+        />
+        <Route
+          path="/ViewMyWorkResult"
+          element={<ViewMyWorkResultCalculate />}
         />
         <Route path="/Login" element={<Login />} />
         <Route path="/SignUp" element={<SignUp />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,12 +34,15 @@ const App = () => {
         <Route path="/ContractReview/" element={<ContractReview />} />
         <Route path="/QuestionAndAnswer" element={<QuestionAndAnswer />} />
         <Route
-          path="/ViewQuestionAndAnswer/:id"
+          path="/ViewQuestionAndAnswer/:worksheetid"
           element={<ViewQuestionAndAnswer />}
         />
         <Route path="/WorkArrangement" element={<WorkArrangement />} />
         <Route path="/ViewMyWork" element={<ViewMyWork />} />
-        <Route path="/ViewMyWorkResult/:id" element={<ViewMyWorkResult />} />
+        <Route
+          path="/ViewMyWorkResult/:worksheetId"
+          element={<ViewMyWorkResult />}
+        />
         <Route path="/Login" element={<Login />} />
         <Route path="/SignUp" element={<SignUp />} />
         <Route path="/MyPage" element={<MyPage />} />

--- a/src/Global/components/Modal.components.jsx
+++ b/src/Global/components/Modal.components.jsx
@@ -7,7 +7,7 @@ import useGlobalState from '../Hooks/useGlobalState';
 import modalStateController from '../function/modalStateController';
 // import ModalResult from './ModalType/ModalResult.components';
 
-const Modal = ({ isOpen, ModalType }) => {
+const Modal = ({ isOpen, ModalType, postData, postContent }) => {
   const { isModalState, setModalState } = useGlobalState();
   useEffect(() => {
     if (isOpen) {
@@ -50,7 +50,9 @@ const Modal = ({ isOpen, ModalType }) => {
           tabIndex="0"
         >
           {/* <ModalResult /> */}
-          {ModalType && <ModalType />}
+          {ModalType && (
+            <ModalType postData={postData} postContent={postContent} />
+          )}
         </div>
       </div>
     </div>
@@ -60,7 +62,46 @@ const Modal = ({ isOpen, ModalType }) => {
 Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   ModalType: PropTypes.elementType.isRequired,
+  postData: PropTypes.shape({
+    data: PropTypes.shape({
+      content: PropTypes.shape({
+        holidayPayMessage: PropTypes.string,
+        incomeTasMessage: PropTypes.string,
+        insuranceMessage: PropTypes.string,
+        nightPayMessage: PropTypes.string,
+        overFiveMessage: PropTypes.string,
+        overtimePayMessage: PropTypes.string,
+        totalPayMessage: PropTypes.string,
+        weekPayMessage: PropTypes.string,
+      }),
+    }),
+    /* eslint-disable camelcase */
+    extra_pay: PropTypes.bool,
+    holiday_money: PropTypes.number,
+    holiday_pay: PropTypes.bool,
+    holiday_work: PropTypes.number,
+    income_tax: PropTypes.bool,
+    major_insurance: PropTypes.bool,
+    night_money: PropTypes.number,
+    night_pay: PropTypes.bool,
+    night_work: PropTypes.number,
+    over_five: PropTypes.bool,
+    overtime_money: PropTypes.number,
+    overtime_pay: PropTypes.bool,
+    overtime_work: PropTypes.number,
+    total_pay: PropTypes.number,
+    week_money: PropTypes.number,
+    week_pay: PropTypes.bool,
+    week_work: PropTypes.number,
+    /* eslint-able camelcase */
+  }),
+  postContent: PropTypes.string,
   // ModalDefaultTypeState: PropTypes.string.isRequired,
+};
+
+Modal.defaultProps = {
+  postData: null, // 기본값 설정
+  postContent: null,
 };
 
 export default Modal;

--- a/src/Global/components/ModalType/ModalResult.components.jsx
+++ b/src/Global/components/ModalType/ModalResult.components.jsx
@@ -55,7 +55,7 @@ const ModalResult = ({ postData, postContent }) => {
       return true;
     }
     // eslint-disable-next-line no-alert
-    alert('모든 필드를 입력해 주세요.');
+    alert('결과지 이름을 입력해주세요.');
     return false;
   };
 

--- a/src/Global/components/ModalType/ModalResult.components.jsx
+++ b/src/Global/components/ModalType/ModalResult.components.jsx
@@ -5,6 +5,7 @@ import useGlobalState from '../../Hooks/useGlobalState';
 import useFetchAPI from '../../API/Hooks/useFetchAPI';
 
 const ModalResult = ({ postData, postContent }) => {
+  console.log('모달 데이터: ', postData);
   // user_id값 임시 지정
   const userID = 2;
   const { setModalType, setWorkSheetId } = useGlobalState();

--- a/src/Global/components/ModalType/ModalResult.components.jsx
+++ b/src/Global/components/ModalType/ModalResult.components.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import '../../css/ModalType/Modal.result.scss';
 import useGlobalState from '../../Hooks/useGlobalState';
 
-const ModalResult = () => {
+const ModalResult = (postData, postContent) => {
   const { setModalType } = useGlobalState();
+  console.log('모달 데이터', postData, postContent);
 
   return (
     <div className="modal-default">

--- a/src/Global/components/ModalType/ModalResult.components.jsx
+++ b/src/Global/components/ModalType/ModalResult.components.jsx
@@ -1,16 +1,103 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../../css/ModalType/Modal.result.scss';
+import PropTypes from 'prop-types';
 import useGlobalState from '../../Hooks/useGlobalState';
+import useFetchAPI from '../../API/Hooks/useFetchAPI';
 
-const ModalResult = (postData, postContent) => {
+const ModalResult = ({ postData, postContent }) => {
+  // user_id값 임시 지정
+  const userID = 2;
   const { setModalType } = useGlobalState();
   console.log('모달 데이터', postData, postContent);
+  const [isContent, setContent] = useState();
+  const [isRequestData, setRequestData] = useState({
+    title: '',
+  });
+  // post
+  const { isData, isLoading, isError, setUrl } = useFetchAPI(
+    '',
+    'POST',
+    isRequestData,
+  );
+  // POST할 이름 변경
+  const transformRequestData = () => {
+    /* eslint-disable camelcase */
+    return {
+      title: `${isRequestData.title} 근로 결과지`,
+      content: postContent,
+      total_pay: postData.total_pay,
+      extra_pay: postData.extra_pay,
+      week_pay: postData.week_pay,
+      night_pay: postData.night_pay,
+      overtime_pay: postData.overtime_pay,
+      holiday_pay: postData.holiday_pay,
+      user_id: userID,
+    };
+    /* eslint-enable camelcase */
+  };
+
+  // 저장하기 버튼 클릭 시 실행할 함수
+  const handleSave = async () => {
+    const requiredFields = Object.keys(isRequestData);
+    const isAllFieldsFilled = requiredFields.every(
+      field => isRequestData[field] !== '',
+    );
+
+    if (isAllFieldsFilled) {
+      const requestData = transformRequestData(
+        isRequestData,
+        postData,
+        postContent,
+      ); // 데이터 변환
+      console.log('Transformed Request Data:', requestData);
+      try {
+        setUrl('worksheet'); // POST 요청 URL 설정
+        setRequestData(requestData); // 변환된 데이터로 요청 설정
+      } catch {
+        console.log('요청 실패...');
+      }
+
+      return true;
+    }
+    // eslint-disable-next-line no-alert
+    alert('모든 필드를 입력해 주세요.');
+    return false;
+  };
+
+  // 입력 필드 채워지는지 콘솔에서 확인
+  useEffect(() => {
+    console.log('Updated isRequestData:', isRequestData);
+  }, [isRequestData]);
+
+  useEffect(() => {
+    if (isLoading) {
+      console.log('..is Loading');
+      setContent('Loading...');
+    } else if (isError) {
+      console.log(`is Error : `, isError);
+      setContent(`Error: `, isError);
+    } else if (isData && isData.data) {
+      console.log(`Success Contact : `, isData);
+      setContent(isData.data);
+      // 요청 성공시 모달 변경
+      setModalType('ResultMessage');
+    } else {
+      setContent(null);
+    }
+  }, [isLoading, isError, isData]);
 
   return (
     <div className="modal-default">
       <div id="modal-title">결과지 이름</div>
       <div className="modal-content">
-        <input placeholder="이름(ex. ㅁㅁ 카페)" type="text" />
+        <input
+          placeholder="이름(ex. ㅁㅁ 카페)"
+          type="text"
+          value={isRequestData.title}
+          onChange={e =>
+            setRequestData({ ...isRequestData, title: e.target.value })
+          }
+        />
         <div id="modal-input-sub">근로 결과지</div>
       </div>
       <div
@@ -21,13 +108,27 @@ const ModalResult = (postData, postContent) => {
         role="button"
         tabIndex="0"
         onClick={() => {
-          setModalType('ResultMessage');
+          handleSave();
         }}
       >
         저장하기
       </div>
     </div>
   );
+};
+
+ModalResult.propTypes = {
+  postData: PropTypes.shape({
+    /* eslint-disable camelcase */
+    total_pay: PropTypes.number,
+    extra_pay: PropTypes.bool,
+    week_pay: PropTypes.bool,
+    night_pay: PropTypes.bool,
+    overtime_pay: PropTypes.bool,
+    holiday_pay: PropTypes.bool,
+    /* eslint-enable camelcase */
+  }).isRequired,
+  postContent: PropTypes.string.isRequired,
 };
 
 export default ModalResult;

--- a/src/Global/components/ModalType/ModalResult.components.jsx
+++ b/src/Global/components/ModalType/ModalResult.components.jsx
@@ -7,8 +7,7 @@ import useFetchAPI from '../../API/Hooks/useFetchAPI';
 const ModalResult = ({ postData, postContent }) => {
   // user_id값 임시 지정
   const userID = 2;
-  const { setModalType } = useGlobalState();
-  console.log('모달 데이터', postData, postContent);
+  const { setModalType, setWorkSheetId } = useGlobalState();
   const [isContent, setContent] = useState();
   const [isRequestData, setRequestData] = useState({
     title: '',
@@ -23,7 +22,7 @@ const ModalResult = ({ postData, postContent }) => {
   const transformRequestData = () => {
     /* eslint-disable camelcase */
     return {
-      title: `${isRequestData.title} 근로 결과지`,
+      title: `${isRequestData.title}`,
       content: postContent,
       total_pay: postData.total_pay,
       extra_pay: postData.extra_pay,
@@ -37,7 +36,7 @@ const ModalResult = ({ postData, postContent }) => {
   };
 
   // 저장하기 버튼 클릭 시 실행할 함수
-  const handleSave = async () => {
+  const handleSave = () => {
     const requiredFields = Object.keys(isRequestData);
     const isAllFieldsFilled = requiredFields.every(
       field => isRequestData[field] !== '',
@@ -50,13 +49,8 @@ const ModalResult = ({ postData, postContent }) => {
         postContent,
       ); // 데이터 변환
       console.log('Transformed Request Data:', requestData);
-      try {
-        setUrl('worksheet'); // POST 요청 URL 설정
-        setRequestData(requestData); // 변환된 데이터로 요청 설정
-      } catch {
-        console.log('요청 실패...');
-      }
-
+      setUrl('worksheet'); // POST 요청 URL 설정
+      setRequestData(requestData); // 변환된 데이터로 요청 설정
       return true;
     }
     // eslint-disable-next-line no-alert
@@ -80,6 +74,7 @@ const ModalResult = ({ postData, postContent }) => {
       console.log(`Success Contact : `, isData);
       setContent(isData.data);
       // 요청 성공시 모달 변경
+      setWorkSheetId(isData.data.worksheet_id);
       setModalType('ResultMessage');
     } else {
       setContent(null);

--- a/src/Global/components/ModalType/ModalResultMessage.components.jsx
+++ b/src/Global/components/ModalType/ModalResultMessage.components.jsx
@@ -1,11 +1,37 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../../css/ModalType/Modal.resultMessage.scss';
 import checkImage from '../../image/modal-check.svg';
 import useGlobalState from '../../Hooks/useGlobalState';
 import modalStateController from '../../function/modalStateController';
+import useFetchAPI from '../../API/Hooks/useFetchAPI';
 
 const ModalResult = () => {
-  const { isModalState, setModalState, setModalType } = useGlobalState();
+  const { isModalState, setModalState, setModalType, isWorkSheetId } =
+    useGlobalState();
+  const { isData, isLoading, isError, setUrl } = useFetchAPI('', 'PUT');
+  const [isContent, setContent] = useState();
+
+  useEffect(() => {
+    if (isLoading) {
+      console.log('..is Loading');
+      setContent('Loading...');
+    } else if (isError) {
+      console.log(`is Error : `, isError);
+      setContent(`Error: `, isError);
+    } else if (isData) {
+      console.log(`Success Contact : `, isData);
+      setContent(isData);
+      setModalType('ShareMessage'); // 모달 타입 변경
+    } else {
+      setContent(null);
+    }
+  }, [isLoading, isError, isData]);
+
+  const handleShare = () => {
+    // 공유하기를 누르면 서버에 PUT 요청을 보냄
+    console.log('WorksheetID: ', isWorkSheetId);
+    setUrl(`worksheet/${isWorkSheetId}`);
+  };
 
   return (
     <div className="modal-result">
@@ -20,9 +46,7 @@ const ModalResult = () => {
           }} // 키보드 지원
           role="button"
           tabIndex="0"
-          onClick={() => {
-            setModalType('ShareMessage');
-          }}
+          onClick={handleShare}
         >
           공유하기
         </div>

--- a/src/Global/components/ModalType/ModalShareMessage.components.jsx
+++ b/src/Global/components/ModalType/ModalShareMessage.components.jsx
@@ -19,9 +19,7 @@ const ModalResult = () => {
           id="modal-share"
           onKeyDown={() => {}}
           onClick={() => {
-            /* eslint-disable-next-line no-alert */
-            alert('다른 결과지 페이지는 준비 중입니다.');
-            navigateController(navigate, '/ViewUsersWorkResult');
+            navigateController(navigate, '/WorkArrangement');
           }}
           role="button"
           tabIndex="0"

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -88,7 +88,9 @@ const VmwrResult = ({ resultId }) => {
   return (
     <div className="vmwr-container">
       <div className="vmwr-contents">
-        <div className="vmwr-result-title">근로 결과지</div>
+        <div className="vmwr-result-title">
+          {isData && isData.data && `${isData.data.title} 근로 결과지`}
+        </div>
         <div>
           {isData &&
             isData.data &&

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -101,7 +101,6 @@ const VmwrResult = ({ resultId, postData, onResultValues }) => {
       .trim()
       .split('니다.')
       .filter(el => el !== ''); // 빈 문자열 제거
-    console.log('ResultContents:', ResultContents);
     resultState = [
       postData.extra_pay,
       postData.week_pay,
@@ -136,7 +135,11 @@ const VmwrResult = ({ resultId, postData, onResultValues }) => {
               const isOverFive =
                 ['야간근로수당', '연장근로수당', '휴일근로수당'].some(keyword =>
                   el.includes(keyword),
-                ) && postData?.over_five === false;
+                ) &&
+                (postData?.over_five === false ||
+                  isData.data.content.includes(
+                    '5인 미만 사업장에서 근무하시기에',
+                  ));
               return (
                 <div
                   key={index}

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -163,7 +163,7 @@ const VmwrResult = ({ resultId, postData }) => {
 };
 
 VmwrResult.propTypes = {
-  resultId: PropTypes.number.isRequired,
+  resultId: PropTypes.number,
   postData: PropTypes.shape({
     data: PropTypes.shape({
       content: PropTypes.shape({
@@ -200,6 +200,7 @@ VmwrResult.propTypes = {
 };
 
 VmwrResult.defaultProps = {
+  resultId: null,
   postData: null, // 기본값 설정
 };
 

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -128,8 +128,19 @@ const VmwrResult = ({ resultId, postData }) => {
         </div>
         <div>
           {((isData && isData.data) || (postData && postData.data)) &&
-            ResultContents.map(el => {
-              return <div key={el}>{el}니다.</div>;
+            ResultContents.map((el, index) => {
+              const isOverFive =
+                ['야간근로수당', '연장근로수당', '휴일근로수당'].some(keyword =>
+                  el.includes(keyword),
+                ) && postData?.over_five === false;
+              return (
+                <div
+                  key={index}
+                  className={isOverFive ? 'vmwr-result-overFive' : ''}
+                >
+                  {el}니다.
+                </div>
+              );
             })}
         </div>
         {/* <div>{content}</div> */}

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -26,7 +26,7 @@ import useFetchAPI from '../API/Hooks/useFetchAPI';
  * @returns {JSX.Element} VmwrResult 컴포넌트
  */
 
-const VmwrResult = ({ resultId, postData }) => {
+const VmwrResult = ({ resultId, postData, onResultValues }) => {
   const { isData, isLoading, isError, setUrl } = useFetchAPI();
   const [isContent, setContent] = useState();
   const [stringifiedValues, setStringifiedValues] = useState('');
@@ -53,10 +53,14 @@ const VmwrResult = ({ resultId, postData }) => {
   useEffect(() => {
     if (postData && postData.data && postData.data.content) {
       const values = Object.values(postData.data.content).join('');
-      console.log('Stringified Values:', values);
+      console.log('content:', values);
       setStringifiedValues(values);
+
+      if (onResultValues) {
+        onResultValues(values);
+      }
     }
-  }, [postData]);
+  }, [postData, onResultValues]);
 
   // fetch 상태 초기 값
   useEffect(() => {
@@ -163,6 +167,7 @@ const VmwrResult = ({ resultId, postData }) => {
 };
 
 VmwrResult.propTypes = {
+  onResultValues: PropTypes.func,
   resultId: PropTypes.number,
   postData: PropTypes.shape({
     data: PropTypes.shape({
@@ -200,6 +205,7 @@ VmwrResult.propTypes = {
 };
 
 VmwrResult.defaultProps = {
+  onResultValues: null,
   resultId: null,
   postData: null, // 기본값 설정
 };

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -26,9 +26,19 @@ import useFetchAPI from '../API/Hooks/useFetchAPI';
  * @returns {JSX.Element} VmwrResult 컴포넌트
  */
 
-const VmwrResult = ({ resultId }) => {
+const VmwrResult = ({ resultId, postData }) => {
   const { isData, isLoading, isError, setUrl } = useFetchAPI();
   const [isContent, setContent] = useState();
+  const [stringifiedValues, setStringifiedValues] = useState('');
+
+  // fetch 상태 초기 값
+  useEffect(() => {
+    if (postData && postData.data && postData.data.content) {
+      const values = Object.values(postData.data.content).join('');
+      console.log('Stringified Values:', values);
+      setStringifiedValues(values);
+    }
+  }, [postData]);
   // WorkSheet 상태 초기 값
   useEffect(() => {
     console.log(resultId);
@@ -40,6 +50,14 @@ const VmwrResult = ({ resultId }) => {
     }
   }, [resultId]);
 
+  useEffect(() => {
+    if (postData && postData.data && postData.data.content) {
+      const values = Object.values(postData.data.content).join('');
+      console.log('Stringified Values:', values);
+      setStringifiedValues(values);
+    }
+  }, [postData]);
+
   // fetch 상태 초기 값
   useEffect(() => {
     if (isLoading) {
@@ -48,16 +66,18 @@ const VmwrResult = ({ resultId }) => {
     } else if (isError) {
       console.log(`is Error : ${isError}`);
       setContent(`Error: ${isError}`);
-    } else if (isData) {
+    } else if (isData && isData.data) {
       setContent(isData);
       console.log(`Success, WorkSheet-Id ${resultId} Contact: `, isData.data);
+    } else if (postData && postData.data) {
+      setContent(postData);
+      console.log(`Success, content is : `, postData);
     } else {
       setContent(null);
     }
-  }, [isLoading, isError, isData]);
+  }, [isLoading, isError, isData, postData]);
 
   // 데이터 검증이 필요
-
   let ResultContents = '';
   let resultState = [];
   if (isData && isData.data) {
@@ -71,6 +91,19 @@ const VmwrResult = ({ resultId }) => {
       isData.data.night_pay,
       isData.data.overtime_pay,
       isData.data.holiday_pay,
+    ];
+  } else if (postData && postData.data) {
+    ResultContents = stringifiedValues
+      .trim()
+      .split('니다.')
+      .filter(el => el !== ''); // 빈 문자열 제거
+    console.log('ResultContents:', ResultContents);
+    resultState = [
+      postData.extra_pay,
+      postData.week_pay,
+      postData.night_pay,
+      postData.overtime_pay,
+      postData.holiday_pay,
     ];
   } else {
     // 데이터가 없을 경우 기본값 설정
@@ -89,11 +122,12 @@ const VmwrResult = ({ resultId }) => {
     <div className="vmwr-container">
       <div className="vmwr-contents">
         <div className="vmwr-result-title">
-          {isData && isData.data && `${isData.data.title} 근로 결과지`}
+          {isData && isData.data
+            ? `${isData.data.title} 근로 결과지`
+            : '근로 결과지'}
         </div>
         <div>
-          {isData &&
-            isData.data &&
+          {((isData && isData.data) || (postData && postData.data)) &&
             ResultContents.map(el => {
               return <div key={el}>{el}니다.</div>;
             })}
@@ -103,8 +137,7 @@ const VmwrResult = ({ resultId }) => {
       <div className="vmwr-group">
         <div className="vmwr-options">발생 요건들</div>
         <div className="vmwr-list">
-          {isData &&
-            isData.data &&
+          {((isData && isData.data) || (postData && postData.data)) &&
             OptionsList.map((option, index) => (
               <VmwrOptionButton
                 key={option}
@@ -120,6 +153,7 @@ const VmwrResult = ({ resultId }) => {
 
 VmwrResult.propTypes = {
   resultId: PropTypes.number.isRequired,
+  postData: PropTypes.isRequired,
 };
 
 export default VmwrResult;

--- a/src/Global/components/VmwrResult.component.jsx
+++ b/src/Global/components/VmwrResult.component.jsx
@@ -164,7 +164,43 @@ const VmwrResult = ({ resultId, postData }) => {
 
 VmwrResult.propTypes = {
   resultId: PropTypes.number.isRequired,
-  postData: PropTypes.isRequired,
+  postData: PropTypes.shape({
+    data: PropTypes.shape({
+      content: PropTypes.shape({
+        holidayPayMessage: PropTypes.string,
+        incomeTasMessage: PropTypes.string,
+        insuranceMessage: PropTypes.string,
+        nightPayMessage: PropTypes.string,
+        overFiveMessage: PropTypes.string,
+        overtimePayMessage: PropTypes.string,
+        totalPayMessage: PropTypes.string,
+        weekPayMessage: PropTypes.string,
+      }),
+    }),
+    /* eslint-disable camelcase */
+    extra_pay: PropTypes.bool,
+    holiday_money: PropTypes.number,
+    holiday_pay: PropTypes.bool,
+    holiday_work: PropTypes.number,
+    income_tax: PropTypes.bool,
+    major_insurance: PropTypes.bool,
+    night_money: PropTypes.number,
+    night_pay: PropTypes.bool,
+    night_work: PropTypes.number,
+    over_five: PropTypes.bool,
+    overtime_money: PropTypes.number,
+    overtime_pay: PropTypes.bool,
+    overtime_work: PropTypes.number,
+    total_pay: PropTypes.number,
+    week_money: PropTypes.number,
+    week_pay: PropTypes.bool,
+    week_work: PropTypes.number,
+    /* eslint-able camelcase */
+  }),
+};
+
+VmwrResult.defaultProps = {
+  postData: null, // 기본값 설정
 };
 
 export default VmwrResult;

--- a/src/Global/css/VmwrResult.component.scss
+++ b/src/Global/css/VmwrResult.component.scss
@@ -16,6 +16,10 @@
 
       div {
         margin-bottom: 12px;
+        color: black;
+        .vmwr-result-overFive {
+          color: gray;
+        }
 
         &:last-child {
           margin-bottom: 24px;

--- a/src/Global/css/VmwrResult.component.scss
+++ b/src/Global/css/VmwrResult.component.scss
@@ -18,10 +18,11 @@
         margin-bottom: 12px;
         color: black;
         .vmwr-result-overFive {
-          color: gray;
+          color: #767676;
         }
 
         &:last-child {
+          margin-top: 24px;
           margin-bottom: 24px;
         }
       }

--- a/src/Page/WorkArrangement/components/ViewMyWork.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWork.jsx
@@ -64,9 +64,12 @@ const ViewMyWork = () => {
 
       setUrl('worksheet/calculate'); // POST 요청 URL 설정
       setRequestData(requestData); // 변환된 데이터로 요청 설정
-    } else {
-      alert('모든 필드를 입력해 주세요.');
+
+      return true;
     }
+    // eslint-disable-next-line no-alert
+    alert('모든 필드를 입력해 주세요.');
+    return false;
   };
   // 입력 필드 채워지는지 콘솔에서 확인
   useEffect(() => {
@@ -83,10 +86,11 @@ const ViewMyWork = () => {
     } else if (isData && isData.data) {
       console.log(`Success Contact : `, isData);
       setContent(isData.data);
+      navigate('/viewMyWorkResult', { state: isData });
     } else {
       setContent(null);
     }
-  }, [isLoading, isError, isData]);
+  }, [isLoading, isError, isData, navigate]);
 
   return (
     <div className="view-my-work">
@@ -114,10 +118,9 @@ const ViewMyWork = () => {
       <button
         className="vmw-result"
         onClick={() => {
-          handleCalculate();
-          if (!isError) {
-            navigate('/viewMyWorkResult');
-            console.log(isData);
+          const isValid = handleCalculate();
+          if (isValid) {
+            // POST 요청 시작
           }
         }}
       >

--- a/src/Page/WorkArrangement/components/ViewMyWork.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWork.jsx
@@ -1,14 +1,82 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../css/ViewMyWork.scss';
+import { useNavigate } from 'react-router-dom';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 import ViewMyWorkOption from './ViewMyWorkOption.component';
 import data from '../data/viewMyWork.data';
+import useFetchAPI from '../../../Global/API/Hooks/useFetchAPI';
 
 const Option = ViewMyWorkOption;
 const OptionsData = data;
 
 const ViewMyWork = () => {
+  const navigate = useNavigate();
+  const [isContent, setContent] = useState();
+  const [isRequestData, setRequestData] = useState({
+    hourPay: '',
+    weekWork: '',
+    overFive: '',
+    overtimeWork: '',
+    nightWork: '',
+    holidayWork: '',
+    // majorInsurance: '',
+    imcomeTax: '',
+  });
+  // post
+  const { isData, isLoading, isError, setUrl } = useFetchAPI(
+    '',
+    'POST',
+    isRequestData,
+  );
+
+  // 입력 필드 변경 함수
+  const handleInputChange = e => {
+    const { name, value } = e.target;
+    setRequestData(prev => ({
+      ...prev,
+      [name]: value, // 기존 선택은 덮어씌움
+    }));
+  };
+
+  // 검사하기 버튼 클릭 시 실행할 함수
+  const handleCalculate = () => {
+    const requiredFields = Object.keys(isRequestData);
+    const isAllFieldsFilled = requiredFields.every(field => {
+      if (field === 'tax' || field === 'overFive') {
+        return isRequestData === 'on';
+      }
+      return isRequestData[field];
+    });
+    // 모든 필드가 채워졌는지 확인
+    if (isAllFieldsFilled) {
+      setUrl('worksheet/calculate'); // 모든 필드가 입력된 경우에만 POST 요청
+    } else {
+      // eslint-disable-next-line no-alert
+      alert('모든 필드를 입력해 주세요.');
+    }
+  };
+
+  // 입력 필드 채워지는지 콘솔에서 확인
+  useEffect(() => {
+    console.log('Updated isRequestData:', isRequestData);
+  }, [isRequestData]);
+
+  useEffect(() => {
+    if (isLoading) {
+      console.log('..is Loading');
+      setContent('Loading...');
+    } else if (isError) {
+      console.log(`is Error : `, isError);
+      setContent(`Error: `, isError);
+    } else if (isData && isData.data) {
+      console.log(`Success Contact : `, isData);
+      setContent(isData.data);
+    } else {
+      setContent(null);
+    }
+  }, [isLoading, isError, isData]);
+
   return (
     <div className="view-my-work">
       <Header />
@@ -26,11 +94,24 @@ const ViewMyWork = () => {
               placeholder={el.placeholder || ''}
               unit={el.unit || ''}
               warning={el.warning}
+              name={el.id}
+              onChange={handleInputChange}
             />
           ))
         }
       </div>
-      <div className="vmw-result">검사하기</div>
+      <button
+        className="vmw-result"
+        onClick={() => {
+          handleCalculate();
+          if (!isError) {
+            navigate('/viewMyWork');
+            console.log(isData);
+          }
+        }}
+      >
+        검사하기
+      </button>
       <Footer />
     </div>
   );

--- a/src/Page/WorkArrangement/components/ViewMyWork.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWork.jsx
@@ -4,11 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 import ViewMyWorkOption from './ViewMyWorkOption.component';
-import data from '../data/viewMyWork.data';
+import OptionsData from '../data/viewMyWork.data';
 import useFetchAPI from '../../../Global/API/Hooks/useFetchAPI';
 
 const Option = ViewMyWorkOption;
-const OptionsData = data;
 
 const ViewMyWork = () => {
   const navigate = useNavigate();
@@ -20,8 +19,7 @@ const ViewMyWork = () => {
     overtimeWork: '',
     nightWork: '',
     holidayWork: '',
-    // majorInsurance: '',
-    imcomeTax: '',
+    tax: '',
   });
   // post
   const { isData, isLoading, isError, setUrl } = useFetchAPI(
@@ -29,7 +27,21 @@ const ViewMyWork = () => {
     'POST',
     isRequestData,
   );
-
+  // POST할 이름 변경
+  const transformRequestData = data => {
+    /* eslint-disable camelcase */
+    return {
+      hour_pay: data.hourPay,
+      week_work: data.weekWork,
+      over_five: data.overFive === 'yes',
+      overtime_work: data.overtimeWork,
+      night_work: data.nightWork,
+      holiday_work: data.holidayWork,
+      major_insurance: data.tax === 'majorInsurance',
+      income_tax: data.tax === 'incomeTax',
+    };
+    /* eslint-enable camelcase */
+  };
   // 입력 필드 변경 함수
   const handleInputChange = e => {
     const { name, value } = e.target;
@@ -42,21 +54,20 @@ const ViewMyWork = () => {
   // 검사하기 버튼 클릭 시 실행할 함수
   const handleCalculate = () => {
     const requiredFields = Object.keys(isRequestData);
-    const isAllFieldsFilled = requiredFields.every(field => {
-      if (field === 'tax' || field === 'overFive') {
-        return isRequestData === 'on';
-      }
-      return isRequestData[field];
-    });
-    // 모든 필드가 채워졌는지 확인
+    const isAllFieldsFilled = requiredFields.every(
+      field => isRequestData[field] !== '',
+    );
+
     if (isAllFieldsFilled) {
-      setUrl('worksheet/calculate'); // 모든 필드가 입력된 경우에만 POST 요청
+      const requestData = transformRequestData(isRequestData); // 데이터 변환
+      console.log('Transformed Request Data:', requestData);
+
+      setUrl('worksheet/calculate'); // POST 요청 URL 설정
+      setRequestData(requestData); // 변환된 데이터로 요청 설정
     } else {
-      // eslint-disable-next-line no-alert
       alert('모든 필드를 입력해 주세요.');
     }
   };
-
   // 입력 필드 채워지는지 콘솔에서 확인
   useEffect(() => {
     console.log('Updated isRequestData:', isRequestData);
@@ -105,7 +116,7 @@ const ViewMyWork = () => {
         onClick={() => {
           handleCalculate();
           if (!isError) {
-            navigate('/viewMyWork');
+            navigate('/viewMyWorkResult');
             console.log(isData);
           }
         }}

--- a/src/Page/WorkArrangement/components/ViewMyWork.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWork.jsx
@@ -21,6 +21,7 @@ const ViewMyWork = () => {
     holidayWork: '',
     tax: '',
   });
+  const [isButtonActive, setButtonActive] = useState(false);
   // post
   const { isData, isLoading, isError, setUrl } = useFetchAPI(
     '',
@@ -73,6 +74,12 @@ const ViewMyWork = () => {
   };
   // 입력 필드 채워지는지 콘솔에서 확인
   useEffect(() => {
+    // 필드가 모두 채워지면 버튼 활성화
+    const requiredFields = Object.keys(isRequestData);
+    const isAllFieldsFilled = requiredFields.every(
+      field => isRequestData[field] !== '',
+    );
+    setButtonActive(isAllFieldsFilled); // 버튼 활성화 여부 설정
     console.log('Updated isRequestData:', isRequestData);
   }, [isRequestData]);
 
@@ -116,7 +123,7 @@ const ViewMyWork = () => {
         }
       </div>
       <button
-        className="vmw-result"
+        className={`vmw-result ${isButtonActive ? 'active' : ''}`}
         onClick={() => {
           const isValid = handleCalculate();
           if (isValid) {

--- a/src/Page/WorkArrangement/components/ViewMyWorkOption.component.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkOption.component.jsx
@@ -12,7 +12,12 @@ const ViewMyWorkOption = ({
   placeholder = '시간을 입력해주세요.',
   unit,
   warning,
+  name,
+  onChange,
 }) => {
+  const handleInputChange = e => {
+    onChange(e);
+  };
   return (
     <div className="vmw-group">
       <div className="vmw-question">
@@ -28,17 +33,31 @@ const ViewMyWorkOption = ({
               placeholder={placeholder}
               unit={unit}
               warning={warning}
+              name={name}
+              onChange={handleInputChange}
             />
           );
           // type: input
         }
         if (type === 'binary') {
           return (
-            <VmwBinaryAnswer placeholder={placeholder} warning={warning} />
+            <VmwBinaryAnswer
+              placeholder={placeholder}
+              warning={warning}
+              name={name}
+              onChange={handleInputChange}
+            />
           );
           // type: binary
         }
-        return <VmwMultiAnswer placeholder={placeholder} warning={warning} />;
+        return (
+          <VmwMultiAnswer
+            placeholder={placeholder}
+            warning={warning}
+            name={name}
+            onChange={handleInputChange}
+          />
+        );
         // type: multi
       })()}
       {/* 삼항연산 방법 -> eslint no-nested-ternary 규칙으로 사용 불가능 */}
@@ -65,6 +84,8 @@ ViewMyWorkOption.propTypes = {
   placeholder: PropTypes.string.isRequired,
   unit: PropTypes.string.isRequired,
   warning: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 // 기본값 설정

--- a/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
@@ -1,20 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import '../css/ViewMyWorkResult.scss';
+import navigateController from '../../../Global/function/navigateController';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 import VmwrResult from '../../../Global/components/VmwrResult.component';
 import useFetchAPI from '../../../Global/API/Hooks/useFetchAPI';
 import useGlobalState from '../../../Global/Hooks/useGlobalState';
-import Modal from '../../../Global/components/Modal.components';
-import ModalResult from '../../../Global/components/ModalType/ModalResult.components';
-import ModalResultMessage from '../../../Global/components/ModalType/ModalResultMessage.components';
-import modalStateController from '../../../Global/function/modalStateController';
-import ModalShareMessage from '../../../Global/components/ModalType/ModalShareMessage.components';
 
 const Result = VmwrResult;
 
 const ViewMyWorkResult = () => {
+  const navigate = useNavigate();
   const { worksheetId } = useParams();
   const { isData, isLoading, isError, setUrl } = useFetchAPI(
     `/worksheet/${worksheetId}`,
@@ -24,15 +21,6 @@ const ViewMyWorkResult = () => {
 
   const { isModalState, setModalState, isModalType, setModalType } =
     useGlobalState();
-
-  // 미리 ModalType 컴포넌트를 설정
-  // ModalType이 변경 되어도 항상 ModalComponent는 ModalResult로 정의 된다.
-  let ModalComponent = ModalResult;
-  if (isModalType === 'ResultMessage') {
-    ModalComponent = ModalResultMessage;
-  } else if (isModalType === 'ShareMessage') {
-    ModalComponent = ModalShareMessage;
-  }
 
   useEffect(() => {
     if (isLoading) {
@@ -52,13 +40,6 @@ const ViewMyWorkResult = () => {
   return (
     <div className="ViewMyWorkResult">
       <Header />
-      {isModalState && (
-        <Modal
-          isOpen={isModalState}
-          ModalType={ModalComponent}
-          // ModalDefaultTypeState={isModalType}
-        />
-      )}
       <div className="vmwr-title">
         {isData && isData.data && isData.data.nickname
           ? `${isData.data.nickname}님의 근로 결과지`
@@ -74,8 +55,7 @@ const ViewMyWorkResult = () => {
           role="button"
           tabIndex="0"
           onClick={() => {
-            setModalType('Result');
-            modalStateController(isModalState, setModalState);
+            navigateController(navigate, '/WorkArrangement/List');
           }}
         >
           목록

--- a/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import '../css/ViewMyWorkResult.scss';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
@@ -14,7 +15,11 @@ import ModalShareMessage from '../../../Global/components/ModalType/ModalShareMe
 const Result = VmwrResult;
 
 const ViewMyWorkResult = () => {
-  const { isData, isLoading, isError, setUrl } = useFetchAPI('/results', 'GET');
+  const { worksheetId } = useParams();
+  const { isData, isLoading, isError, setUrl } = useFetchAPI(
+    `/worksheet/${worksheetId}`,
+    'GET',
+  );
   const [content, setContent] = useState(''); // 렌더링할 content 상태 관리
 
   const { isModalState, setModalState, isModalType, setModalType } =
@@ -38,7 +43,7 @@ const ViewMyWorkResult = () => {
       setContent(`Error: ${isError}`);
     } else if (isData) {
       console.log(`Success Contact : ${isData}`);
-      setContent(<Result data={isData} />);
+      setContent(<Result resultId={worksheetId} />);
     } else {
       setContent(null);
     }
@@ -54,7 +59,11 @@ const ViewMyWorkResult = () => {
           // ModalDefaultTypeState={isModalType}
         />
       )}
-      <div className="vmwr-title">내 근로 결과지</div>
+      <div className="vmwr-title">
+        {isData && isData.data && isData.data.nickname
+          ? `${isData.data.nickname}님의 근로 결과지`
+          : '내 근로 결과지'}
+      </div>
       <div className="vmwr-result">{content}</div>
       <div id="vmwr-group">
         <div

--- a/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResult.jsx
@@ -78,7 +78,7 @@ const ViewMyWorkResult = () => {
             modalStateController(isModalState, setModalState);
           }}
         >
-          결과지 저장하기
+          목록
         </div>
       </div>
       <Footer />

--- a/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import '../css/ViewMyWorkResult.scss';
+import Header from '../../Header/components/Header';
+import Footer from '../../Footer/components/Footer';
+import VmwrResult from '../../../Global/components/VmwrResult.component';
+import useGlobalState from '../../../Global/Hooks/useGlobalState';
+import Modal from '../../../Global/components/Modal.components';
+import ModalResult from '../../../Global/components/ModalType/ModalResult.components';
+import ModalResultMessage from '../../../Global/components/ModalType/ModalResultMessage.components';
+import modalStateController from '../../../Global/function/modalStateController';
+import ModalShareMessage from '../../../Global/components/ModalType/ModalShareMessage.components';
+
+const Result = VmwrResult;
+
+const ViewMyWorkResult = () => {
+  const [content, setContent] = useState(''); // 렌더링할 content 상태 관리
+
+  const { isModalState, setModalState, isModalType, setModalType } =
+    useGlobalState();
+  const location = useLocation();
+  const { state: postData } = location || {}; // POST로 전달된 데이터
+
+  useEffect(() => {
+    if (postData) {
+      console.log('POST 응답 데이터:', postData.data);
+      setContent(<Result postData={postData} />);
+    }
+  }, [postData]);
+  // 미리 ModalType 컴포넌트를 설정
+  // ModalType이 변경 되어도 항상 ModalComponent는 ModalResult로 정의 된다.
+  let ModalComponent = ModalResult;
+  if (isModalType === 'ResultMessage') {
+    ModalComponent = ModalResultMessage;
+  } else if (isModalType === 'ShareMessage') {
+    ModalComponent = ModalShareMessage;
+  }
+
+  return (
+    <div className="ViewMyWorkResult">
+      <Header />
+      {isModalState && (
+        <Modal
+          isOpen={isModalState}
+          ModalType={ModalComponent}
+          // ModalDefaultTypeState={isModalType}
+        />
+      )}
+      <div className="vmwr-title">
+        {postData && postData.data && postData.data.nickname
+          ? `${postData.data.nickname}님의 근로 결과지`
+          : '내 근로 결과지'}
+      </div>
+      <div className="vmwr-result">{content}</div>
+      <div id="vmwr-group">
+        <div
+          className="vmwr-button"
+          onKeyDown={() => {
+            console.log('test');
+          }}
+          role="button"
+          tabIndex="0"
+          onClick={() => {
+            setModalType('Result');
+            modalStateController(isModalState, setModalState);
+          }}
+        >
+          결과지 저장하기
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default ViewMyWorkResult;

--- a/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import '../css/ViewMyWorkResult.scss';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
@@ -15,8 +15,10 @@ import generateResultContent from '../function/generateResultContent';
 const Result = VmwrResult;
 
 const ViewMyWorkResult = () => {
+  const navigate = useNavigate();
   const [content, setContent] = useState(''); // 렌더링할 content 상태 관리
   const [resultValues, setResultValues] = useState('');
+  const [resData, setResData] = useState(null);
 
   const handleResultValues = values => {
     setResultValues(values); // 자식에서 전달받은 값을 저장
@@ -27,17 +29,19 @@ const ViewMyWorkResult = () => {
     useGlobalState();
   const location = useLocation();
   const { state: postData } = location || {}; // POST로 전달된 데이터
-  const resData = generateResultContent(postData.data);
-  console.log('가공된 데이터', resData);
-
   useEffect(() => {
-    if (postData) {
-      console.log('POST 응답 데이터:', postData.data);
+    if (!postData || !postData.data) {
+      // postData가 없거나 데이터가 없는 경우
+      navigate('/ViewMyWork'); // ViewMyWork 페이지로 리디렉션
+    } else {
+      const processedData = generateResultContent(postData.data);
+      console.log('가공된 데이터', processedData);
+      setResData(processedData);
       setContent(
-        <Result postData={resData} onResultValues={handleResultValues} />,
+        <Result postData={processedData} onResultValues={handleResultValues} />,
       );
     }
-  }, [postData]);
+  }, [postData, navigate]);
   // 미리 ModalType 컴포넌트를 설정
   // ModalType이 변경 되어도 항상 ModalComponent는 ModalResult로 정의 된다.
   let ModalComponent = ModalResult;

--- a/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
@@ -16,6 +16,12 @@ const Result = VmwrResult;
 
 const ViewMyWorkResult = () => {
   const [content, setContent] = useState(''); // 렌더링할 content 상태 관리
+  const [resultValues, setResultValues] = useState('');
+
+  const handleResultValues = values => {
+    setResultValues(values); // 자식에서 전달받은 값을 저장
+    console.log('Parent received ResultContents:', values);
+  };
 
   const { isModalState, setModalState, isModalType, setModalType } =
     useGlobalState();
@@ -27,7 +33,9 @@ const ViewMyWorkResult = () => {
   useEffect(() => {
     if (postData) {
       console.log('POST 응답 데이터:', postData.data);
-      setContent(<Result postData={resData} />);
+      setContent(
+        <Result postData={resData} onResultValues={handleResultValues} />,
+      );
     }
   }, [postData]);
   // 미리 ModalType 컴포넌트를 설정
@@ -46,14 +54,12 @@ const ViewMyWorkResult = () => {
         <Modal
           isOpen={isModalState}
           ModalType={ModalComponent}
+          postData={resData}
+          postContent={resultValues}
           // ModalDefaultTypeState={isModalType}
         />
       )}
-      <div className="vmwr-title">
-        {postData && postData.data && postData.data.nickname
-          ? `${postData.data.nickname}님의 근로 결과지`
-          : '내 근로 결과지'}
-      </div>
+      <div className="vmwr-title">내 근로 결과지</div>
       <div className="vmwr-result">{content}</div>
       <div id="vmwr-group">
         <div

--- a/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
@@ -10,6 +10,7 @@ import ModalResult from '../../../Global/components/ModalType/ModalResult.compon
 import ModalResultMessage from '../../../Global/components/ModalType/ModalResultMessage.components';
 import modalStateController from '../../../Global/function/modalStateController';
 import ModalShareMessage from '../../../Global/components/ModalType/ModalShareMessage.components';
+import generateResultContent from '../function/generateResultContent';
 
 const Result = VmwrResult;
 
@@ -20,11 +21,13 @@ const ViewMyWorkResult = () => {
     useGlobalState();
   const location = useLocation();
   const { state: postData } = location || {}; // POST로 전달된 데이터
+  const resData = generateResultContent(postData.data);
+  console.log('가공된 데이터', resData);
 
   useEffect(() => {
     if (postData) {
       console.log('POST 응답 데이터:', postData.data);
-      setContent(<Result postData={postData} />);
+      setContent(<Result postData={resData} />);
     }
   }, [postData]);
   // 미리 ModalType 컴포넌트를 설정

--- a/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
+++ b/src/Page/WorkArrangement/components/ViewMyWorkResultCalculate.jsx
@@ -32,6 +32,10 @@ const ViewMyWorkResult = () => {
   useEffect(() => {
     if (!postData || !postData.data) {
       // postData가 없거나 데이터가 없는 경우
+      // eslint-disable-next-line no-alert
+      alert(
+        '해당 페이지는 근로결과지를 작성한 후 넘어가는 페이지입니다. 근로결과지 작성 페이지로 넘어갑니다.',
+      );
       navigate('/ViewMyWork'); // ViewMyWork 페이지로 리디렉션
     } else {
       const processedData = generateResultContent(postData.data);

--- a/src/Page/WorkArrangement/components/WorkArrangement.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangement.jsx
@@ -66,11 +66,11 @@ const WorkArrangement = () => {
                   id={item.id}
                   title={item.title}
                   content={item.content}
-                  extra_pay={item.extra_pay}
-                  week_pay={item.week_pay}
-                  night_pay={item.night_pay}
-                  overtime_pay={item.overtime_pay}
-                  holiday_pay={item.holiday_pay}
+                  extraPay={item.extra_pay}
+                  weekPay={item.week_pay}
+                  nightPay={item.night_pay}
+                  overtimePay={item.overtime_pay}
+                  holidayPay={item.holiday_pay}
                 />
               ))
             : !isLoading && !isError && <p>No data available</p>}

--- a/src/Page/WorkArrangement/components/WorkArrangement.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangement.jsx
@@ -60,28 +60,28 @@ const WorkArrangement = () => {
           {isLoading && <p>Loading...</p>}
           {!isLoading && isError && <p>Error: {isError.message}</p>}
           {!isLoading && isData && isData.data
-            ? isData.data.map(item => (
-                <WorkArrangementResult
-                  key={item.id}
-                  id={item.worksheet_id}
-                  title={item.title}
-                  content={item.content}
-                  extraPay={item.extra_pay}
-                  weekPay={item.week_pay}
-                  nightPay={item.night_pay}
-                  overtimePay={item.overtime_pay}
-                  holidayPay={item.holiday_pay}
-                />
-              ))
+            ? isData.data
+                .slice(0, 3)
+                .map(item => (
+                  <WorkArrangementResult
+                    key={item.id}
+                    id={item.worksheet_id}
+                    title={item.title}
+                    content={item.content}
+                    extraPay={item.extra_pay}
+                    weekPay={item.week_pay}
+                    nightPay={item.night_pay}
+                    overtimePay={item.overtime_pay}
+                    holidayPay={item.holiday_pay}
+                  />
+                ))
             : !isLoading && !isError && <p>No data available</p>}
           <div className="wa-short-cut-button">
             <div
               className="wa-short-cut"
               onKeyDown={() => {}}
               onClick={() => {
-                /* eslint-disable-next-line no-alert */
-                alert('다른 결과지 페이지는 준비 중입니다.');
-                navigateController(navigate, '/ViewUsersWorkResult');
+                navigateController(navigate, './List');
               }}
               role="button"
               tabIndex="0"

--- a/src/Page/WorkArrangement/components/WorkArrangement.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangement.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import quizImage from '../image/quiz-short-cut.svg';
 import '../css/WorkArrangement.scss';
@@ -6,10 +6,30 @@ import navigateController from '../../../Global/function/navigateController';
 import Header from '../../Header/components/Header';
 import Footer from '../../Footer/components/Footer';
 import WorkArrangementResult from './WorkArrangementResult.component';
+import useFetchAPI from '../../../Global/API/Hooks/useFetchAPI';
 
 const WorkArrangement = () => {
   // useNavigate 사용하기 위한 변수 정의
   const navigate = useNavigate();
+  const [isContent, setContent] = useState('');
+  const { isData, isLoading, isError, setUrl } = useFetchAPI();
+
+  // API 요청을 위한 URL 설정
+  useEffect(() => {
+    setUrl('/worksheet/list');
+  }, [setUrl]);
+
+  useEffect(() => {
+    if (isLoading) {
+      setContent('Loading...');
+    } else if (isError) {
+      setContent(`Error: ${isError}`);
+    } else if (isData) {
+      setContent(isData);
+    } else {
+      setContent(null);
+    }
+  }, [isLoading, isError, isData]);
 
   return (
     <div className="work-arrangement">
@@ -37,7 +57,23 @@ const WorkArrangement = () => {
         </div>
         <div className="wa-contents">
           <div className="wa-title">다른 결과지들은 어떨까요?</div>
-          <WorkArrangementResult />
+          {isLoading && <p>Loading...</p>}
+          {!isLoading && isError && <p>Error: {isError.message}</p>}
+          {!isLoading && isData && isData.data
+            ? isData.data.map(item => (
+                <WorkArrangementResult
+                  key={item.id}
+                  id={item.id}
+                  title={item.title}
+                  content={item.content}
+                  extra_pay={item.extra_pay}
+                  week_pay={item.week_pay}
+                  night_pay={item.night_pay}
+                  overtime_pay={item.overtime_pay}
+                  holiday_pay={item.holiday_pay}
+                />
+              ))
+            : !isLoading && !isError && <p>No data available</p>}
           <div className="wa-short-cut-button">
             <div
               className="wa-short-cut"

--- a/src/Page/WorkArrangement/components/WorkArrangement.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangement.jsx
@@ -63,7 +63,7 @@ const WorkArrangement = () => {
             ? isData.data.map(item => (
                 <WorkArrangementResult
                   key={item.id}
-                  id={item.id}
+                  id={item.worksheet_id}
                   title={item.title}
                   content={item.content}
                   extraPay={item.extra_pay}

--- a/src/Page/WorkArrangement/components/WorkArrangementList.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementList.jsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import '../css/WorkArrangement.scss';
+import Header from '../../Header/components/Header';
+import Footer from '../../Footer/components/Footer';
+import WorkArrangementResult from './WorkArrangementResult.component';
+import useFetchAPI from '../../../Global/API/Hooks/useFetchAPI';
+
+const WorkArrangementList = () => {
+  // useNavigate 사용하기 위한 변수 정의
+  const [isContent, setContent] = useState('');
+  const { isData, isLoading, isError, setUrl } = useFetchAPI();
+
+  // API 요청을 위한 URL 설정
+  useEffect(() => {
+    setUrl('/worksheet/list');
+  }, [setUrl]);
+
+  useEffect(() => {
+    if (isLoading) {
+      setContent('Loading...');
+    } else if (isError) {
+      setContent(`Error: ${isError}`);
+    } else if (isData) {
+      setContent(isData);
+    } else {
+      setContent(null);
+    }
+  }, [isLoading, isError, isData]);
+
+  return (
+    <div className="work-arrangement">
+      <Header />
+      <div className="wa-container">
+        <div className="wa-contents">
+          <div id="wa-title">다른 근로 결과지들은 어떨까요?</div>
+          {isLoading && <p>Loading...</p>}
+          {!isLoading && isError && <p>Error: {isError.message}</p>}
+          {!isLoading && isData && isData.data
+            ? isData.data.map(item => (
+                <WorkArrangementResult
+                  key={item.id}
+                  id={item.worksheet_id}
+                  title={item.title}
+                  content={item.content}
+                  extraPay={item.extra_pay}
+                  weekPay={item.week_pay}
+                  nightPay={item.night_pay}
+                  overtimePay={item.overtime_pay}
+                  holidayPay={item.holiday_pay}
+                />
+              ))
+            : !isLoading && !isError && <p>No data available</p>}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default WorkArrangementList;

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -41,9 +41,9 @@ const WorkArrangementResult = ({
           onKeyDown={() => {}}
           onClick={() => {
             /* eslint-disable-next-line no-alert */
-            alert(
-              '해당 페이지는 workSheet와 같은 고유 아이디를 받아 특정 결과지 페이지로 넘어가야 합니다. 우선 ViewMyWorkResult로 넘거 갑니다.',
-            );
+            // alert( // 경고문 불필요해서 주석처리
+            //   '해당 페이지는 workSheet와 같은 고유 아이디를 받아 특정 결과지 페이지로 넘어가야 합니다. 우선 ViewMyWorkResult로 넘거 갑니다.',
+            // );
             navigateController(navigate, `/ViewMyWorkResult/${id}`);
           }}
           role="button"

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -32,6 +32,13 @@ const WorkArrangementResult = ({
   const firstRowOptions = OptionsList.slice(0, 3);
   const secondRowOptions = OptionsList.slice(3);
 
+  // content를 split
+  const splitContent = content
+    .trim()
+    .split('니다.')
+    .filter(el => el !== '')
+    .map(el => `${el}니다.`);
+
   return (
     <div className="wa-result">
       <div className="wa-control">
@@ -56,7 +63,11 @@ const WorkArrangementResult = ({
         </div>
       </div>
       <div className="wa-group">
-        <div className="wa-description">{content}</div>
+        <div className="wa-description">
+          {splitContent.slice(0, 4).map((line, index) => (
+            <div key={index}>{index === 3 ? `${line}..` : line}</div>
+          ))}
+        </div>
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -18,6 +18,35 @@ const WorkArrangementResult = ({
 }) => {
   const navigate = useNavigate();
 
+  // 조건에 따라 상단(true)과 하단(false) 배열을 생성
+  const conditions = [
+    { label: '주휴수당', value: weekPay },
+    { label: '가산수당', value: extraPay },
+    { label: '야간근로수당', value: nightPay },
+    { label: '연장근로수당', value: overtimePay },
+    { label: '휴일근로수당', value: holidayPay },
+  ];
+
+  const trueConditions = conditions.filter(cond => cond.value === true);
+  const falseConditions = conditions.filter(cond => cond.value === false);
+
+  const renderConditions = conditionArray => {
+    return (
+      <>
+        {conditionArray.slice(0, 3).map((cond, index) => (
+          <div
+            key={index}
+            id="wa-option"
+            className={`waOption ${optionColor(cond.value)}`}
+          >
+            {cond.label}
+          </div>
+        ))}
+        {conditionArray.length > 3 && <div className="waOption more">...</div>}
+      </>
+    );
+  };
+
   return (
     <div className="wa-result">
       <div className="wa-control">
@@ -46,26 +75,11 @@ const WorkArrangementResult = ({
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>
-            <div id="wa-option" className={`waOption ${optionColor(weekPay)}`}>
-              주휴수당
+            <div className="wa-true-options">
+              {renderConditions(trueConditions)}
             </div>
-            <div id="wa-option" className={`waOption ${optionColor(extraPay)}`}>
-              가산수당
-            </div>
-            <div id="wa-option" className={`waOption ${optionColor(nightPay)}`}>
-              야간근로수당
-            </div>
-            <div
-              id="wa-option"
-              className={`waOption ${optionColor(overtimePay)}`}
-            >
-              연장근로수당
-            </div>
-            <div
-              id="wa-option"
-              className={`waOption ${optionColor(holidayPay)}`}
-            >
-              휴일근로수당
+            <div className="wa-false-options">
+              {renderConditions(falseConditions)}
             </div>
           </div>
         </div>

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import '../css/WorkArrangementResult.scss';
 import { useNavigate } from 'react-router-dom';
+import '../css/WorkArrangementResult.scss';
 import navigateController from '../../../Global/function/navigateController';
 import arrowRight from '../image/arrow-right.svg';
+import optionColor from '../function/optionColor';
 
 // key={item.id}
 // id={item.id}
@@ -15,7 +16,17 @@ import arrowRight from '../image/arrow-right.svg';
 // overtime_pay={item.overtime_pay}
 // holiday_pay={item.holiday_pay}
 
-const WorkArrangementResult = ({ id, title, content }) => {
+const WorkArrangementResult = ({
+  id,
+  title,
+  content,
+  extraPay,
+  weekPay,
+  nightPay,
+  // timePay,
+  overtimePay,
+  holidayPay,
+}) => {
   const navigate = useNavigate();
 
   return (
@@ -46,7 +57,27 @@ const WorkArrangementResult = ({ id, title, content }) => {
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>
-            <div id="wa-option">주휴수당</div>
+            <div id="wa-option" className={`waOption ${optionColor(weekPay)}`}>
+              주휴수당
+            </div>
+            <div id="wa-option" className={`waOption ${optionColor(extraPay)}`}>
+              가산수당
+            </div>
+            <div id="wa-option" className={`waOption ${optionColor(nightPay)}`}>
+              야간근로수당
+            </div>
+            <div
+              id="wa-option"
+              className={`waOption ${optionColor(overtimePay)}`}
+            >
+              연장근로수당
+            </div>
+            <div
+              id="wa-option"
+              className={`waOption ${optionColor(holidayPay)}`}
+            >
+              휴일근로수당
+            </div>
           </div>
         </div>
       </div>
@@ -58,6 +89,12 @@ WorkArrangementResult.propTypes = {
   id: PropTypes.number.isRequired, // id string
   title: PropTypes.string.isRequired, // title string
   content: PropTypes.string.isRequired, // content string
+  extraPay: PropTypes.bool.isRequired, // extraPay bool
+  weekPay: PropTypes.bool.isRequired, // weekPay bool
+  // timePay: PropTypes.bool.isRequired, // timePay bool
+  nightPay: PropTypes.bool.isRequired, // nightPay bool
+  overtimePay: PropTypes.bool.isRequired, // overtimePay bool
+  holidayPay: PropTypes.bool.isRequired, // holidayPay bool
 };
 
 export default WorkArrangementResult;

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -6,16 +6,6 @@ import navigateController from '../../../Global/function/navigateController';
 import arrowRight from '../image/arrow-right.svg';
 import optionColor from '../function/optionColor';
 
-// key={item.id}
-// id={item.id}
-// title={item.title}
-// content={item.content}
-// extra_pay={item.extra_pay}
-// week_pay={item.week_pay}
-// night_pay={item.night_pay}
-// overtime_pay={item.overtime_pay}
-// holiday_pay={item.holiday_pay}
-
 const WorkArrangementResult = ({
   id,
   title,
@@ -23,7 +13,6 @@ const WorkArrangementResult = ({
   extraPay,
   weekPay,
   nightPay,
-  // timePay,
   overtimePay,
   holidayPay,
 }) => {
@@ -91,7 +80,6 @@ WorkArrangementResult.propTypes = {
   content: PropTypes.string.isRequired, // content string
   extraPay: PropTypes.bool.isRequired, // extraPay bool
   weekPay: PropTypes.bool.isRequired, // weekPay bool
-  // timePay: PropTypes.bool.isRequired, // timePay bool
   nightPay: PropTypes.bool.isRequired, // nightPay bool
   overtimePay: PropTypes.bool.isRequired, // overtimePay bool
   holidayPay: PropTypes.bool.isRequired, // holidayPay bool

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -28,6 +28,10 @@ const WorkArrangementResult = ({
     '휴일근로수당',
   ];
 
+  // 배열을 두 줄로 나눔
+  const firstRowOptions = OptionsList.slice(0, 3);
+  const secondRowOptions = OptionsList.slice(3);
+
   return (
     <div className="wa-result">
       <div className="wa-control">
@@ -56,13 +60,26 @@ const WorkArrangementResult = ({
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>
-            {OptionsList.map((option, index) => (
-              <VmwrOptionButton
-                key={option}
-                resultState={resultState[index] ? 'check' : 'uncheck'}
-                option={option}
-              />
-            ))}
+            <div className="wa-list">
+              <div className="wa-row">
+                {firstRowOptions.map((option, index) => (
+                  <VmwrOptionButton
+                    key={option}
+                    resultState={resultState[index] ? 'check' : 'uncheck'}
+                    option={option}
+                  />
+                ))}
+              </div>
+              <div className="wa-row">
+                {secondRowOptions.map((option, index) => (
+                  <VmwrOptionButton
+                    key={option}
+                    resultState={resultState[index + 3] ? 'check' : 'uncheck'}
+                    option={option}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../css/WorkArrangementResult.scss';
 import { useNavigate } from 'react-router-dom';
 import navigateController from '../../../Global/function/navigateController';
 import arrowRight from '../image/arrow-right.svg';
 
-const WorkArrangementResult = () => {
+// key={item.id}
+// id={item.id}
+// title={item.title}
+// content={item.content}
+// extra_pay={item.extra_pay}
+// week_pay={item.week_pay}
+// night_pay={item.night_pay}
+// overtime_pay={item.overtime_pay}
+// holiday_pay={item.holiday_pay}
+
+const WorkArrangementResult = ({ id, title, content }) => {
   const navigate = useNavigate();
 
   return (
     <div className="wa-result">
       <div className="wa-control">
-        <div id="wa-title">미도인 성수 근로 결과지</div>
+        <div id="wa-title">{title}</div>
         <div
           id="wa-short-cut"
           onKeyDown={() => {}}
@@ -19,7 +30,7 @@ const WorkArrangementResult = () => {
             alert(
               '해당 페이지는 workSheet와 같은 고유 아이디를 받아 특정 결과지 페이지로 넘어가야 합니다. 우선 ViewMyWorkResult로 넘거 갑니다.',
             );
-            navigateController(navigate, '/ViewMyWorkResult');
+            navigateController(navigate, `/ViewMyWorkResult/${id}`);
           }}
           role="button"
           tabIndex="0"
@@ -31,20 +42,7 @@ const WorkArrangementResult = () => {
         </div>
       </div>
       <div className="wa-group">
-        <div className="wa-description">
-          <div>
-            상시 5인 미만 사업장에서 근무하시므로 추가적인 가산 수당이 없습니다.
-          </div>
-          <div>
-            상시 5인 미만 사업장에서 근무하시므로 추가적인 가산 수당이 없습니다.
-          </div>
-          <div>
-            상시 5인 미만 사업장에서 근무하시므로 추가적인 가산 수당이 없습니다.
-          </div>
-          <div>
-            상시 5인 미만 사업장에서 근무하시므로 추가적인 가산 수당이 없습니다.
-          </div>
-        </div>
+        <div className="wa-description">{content}</div>
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>
@@ -54,6 +52,12 @@ const WorkArrangementResult = () => {
       </div>
     </div>
   );
+};
+
+WorkArrangementResult.propTypes = {
+  id: PropTypes.number.isRequired, // id string
+  title: PropTypes.string.isRequired, // title string
+  content: PropTypes.string.isRequired, // content string
 };
 
 export default WorkArrangementResult;

--- a/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
+++ b/src/Page/WorkArrangement/components/WorkArrangementResult.component.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import '../css/WorkArrangementResult.scss';
+import VmwrOptionButton from './VmwrButton.component';
 import navigateController from '../../../Global/function/navigateController';
 import arrowRight from '../image/arrow-right.svg';
-import optionColor from '../function/optionColor';
 
 const WorkArrangementResult = ({
   id,
@@ -18,39 +18,20 @@ const WorkArrangementResult = ({
 }) => {
   const navigate = useNavigate();
 
-  // 조건에 따라 상단(true)과 하단(false) 배열을 생성
-  const conditions = [
-    { label: '주휴수당', value: weekPay },
-    { label: '가산수당', value: extraPay },
-    { label: '야간근로수당', value: nightPay },
-    { label: '연장근로수당', value: overtimePay },
-    { label: '휴일근로수당', value: holidayPay },
+  const resultState = [extraPay, weekPay, nightPay, overtimePay, holidayPay];
+
+  const OptionsList = [
+    '가산수당',
+    '주휴수당',
+    '야간근로수당',
+    '연장근로수당',
+    '휴일근로수당',
   ];
-
-  const trueConditions = conditions.filter(cond => cond.value === true);
-  const falseConditions = conditions.filter(cond => cond.value === false);
-
-  const renderConditions = conditionArray => {
-    return (
-      <>
-        {conditionArray.slice(0, 3).map((cond, index) => (
-          <div
-            key={index}
-            id="wa-option"
-            className={`waOption ${optionColor(cond.value)}`}
-          >
-            {cond.label}
-          </div>
-        ))}
-        {conditionArray.length > 3 && <div className="waOption more">...</div>}
-      </>
-    );
-  };
 
   return (
     <div className="wa-result">
       <div className="wa-control">
-        <div id="wa-title">{title}</div>
+        <div id="wa-title">{title} 근로 결과지</div>
         <div
           id="wa-short-cut"
           onKeyDown={() => {}}
@@ -75,12 +56,13 @@ const WorkArrangementResult = ({
         <div className="wa-options">
           <div className="wa-contents">
             <div className="wa-title">발생 요건들</div>
-            <div className="wa-true-options">
-              {renderConditions(trueConditions)}
-            </div>
-            <div className="wa-false-options">
-              {renderConditions(falseConditions)}
-            </div>
+            {OptionsList.map((option, index) => (
+              <VmwrOptionButton
+                key={option}
+                resultState={resultState[index] ? 'check' : 'uncheck'}
+                option={option}
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/src/Page/WorkArrangement/components/type/VmwBinaryAnswer.component.jsx
+++ b/src/Page/WorkArrangement/components/type/VmwBinaryAnswer.component.jsx
@@ -8,14 +8,26 @@ import PropTypes from 'prop-types';
  * @param {string} props.warning - The warning message to display.
  */
 
-const VmwBinaryAnswer = ({ placeholder, warning }) => {
+const VmwBinaryAnswer = ({ warning, name, onChange }) => {
   return (
     <div className="vmw-yesOrNo-answer">
       <div className="vmw-input-group">
         <span>예</span>
-        <input id="input-styled" type="checkbox" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="radio"
+          name={name}
+          onChange={onChange}
+          value="yes"
+        />
         <span>아니오</span>
-        <input id="input-styled" type="checkbox" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="radio"
+          name={name}
+          onChange={onChange}
+          value="no"
+        />
       </div>
       <span id="input-warning-message">{warning}</span>
     </div>
@@ -23,8 +35,9 @@ const VmwBinaryAnswer = ({ placeholder, warning }) => {
 };
 
 VmwBinaryAnswer.propTypes = {
-  placeholder: PropTypes.string.isRequired,
   warning: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default VmwBinaryAnswer;

--- a/src/Page/WorkArrangement/components/type/VmwInputAnswer.component.jsx
+++ b/src/Page/WorkArrangement/components/type/VmwInputAnswer.component.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const VmwInputAnswer = ({ placeholder, unit, warning }) => {
+const VmwInputAnswer = ({ placeholder, unit, warning, name, onChange }) => {
   return (
     <div className="vmw-input-answer">
       <div className="vmw-input-group">
-        <input id="input-styled" type="input" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="input"
+          placeholder={placeholder}
+          name={name}
+          onChange={onChange}
+        />
         <span>{unit}</span>
       </div>
       <span id="input-warning-message">{warning}</span>
@@ -17,6 +23,8 @@ VmwInputAnswer.propTypes = {
   placeholder: PropTypes.string.isRequired,
   unit: PropTypes.string.isRequired,
   warning: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default VmwInputAnswer;

--- a/src/Page/WorkArrangement/components/type/VmwMultiAnswer.component.jsx
+++ b/src/Page/WorkArrangement/components/type/VmwMultiAnswer.component.jsx
@@ -1,16 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const VmwCheckboxAnswer = ({ placeholder, warning }) => {
+const VmwCheckboxAnswer = ({ placeholder, warning, name, onChange }) => {
   return (
     <div className="vmw-checkbox-answer">
       <div className="vmw-input-group">
         <span>적용안함</span>
-        <input id="input-styled" type="checkbox" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="radio"
+          placeholder={placeholder}
+          name={name}
+          onChange={onChange}
+          value="none"
+        />
         <span>4대보험(9.32%)</span>
-        <input id="input-styled" type="checkbox" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="radio"
+          placeholder={placeholder}
+          name={name}
+          onChange={onChange}
+          value="majorInsurance"
+        />
         <span>소득세(3.3%)</span>
-        <input id="input-styled" type="checkbox" placeholder={placeholder} />
+        <input
+          id="input-styled"
+          type="radio"
+          placeholder={placeholder}
+          name={name}
+          onChange={onChange}
+          value="incomeTax"
+        />
       </div>
       <span id="input-warning-message">{warning}</span>
     </div>
@@ -20,6 +41,8 @@ const VmwCheckboxAnswer = ({ placeholder, warning }) => {
 VmwCheckboxAnswer.propTypes = {
   placeholder: PropTypes.string.isRequired,
   warning: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default VmwCheckboxAnswer;

--- a/src/Page/WorkArrangement/components/type/VmwMultiAnswer.component.jsx
+++ b/src/Page/WorkArrangement/components/type/VmwMultiAnswer.component.jsx
@@ -9,7 +9,7 @@ const VmwCheckboxAnswer = ({ placeholder, warning }) => {
         <input id="input-styled" type="checkbox" placeholder={placeholder} />
         <span>4대보험(9.32%)</span>
         <input id="input-styled" type="checkbox" placeholder={placeholder} />
-        <span>소득세(3.3%)(9.32%)</span>
+        <span>소득세(3.3%)</span>
         <input id="input-styled" type="checkbox" placeholder={placeholder} />
       </div>
       <span id="input-warning-message">{warning}</span>

--- a/src/Page/WorkArrangement/css/ViewMyWork.scss
+++ b/src/Page/WorkArrangement/css/ViewMyWork.scss
@@ -180,11 +180,11 @@
     letter-spacing: -0.025em;
     margin-bottom: 120px;
     border: none;
-    cursor: pointer;
 
     &.active {
       background-color: #1bbfc1;
       color: #ffffff;
+      cursor: pointer;
     }
   }
 }

--- a/src/Page/WorkArrangement/css/ViewMyWork.scss
+++ b/src/Page/WorkArrangement/css/ViewMyWork.scss
@@ -179,6 +179,13 @@
     line-height: 28px;
     letter-spacing: -0.025em;
     margin-bottom: 120px;
+    border: none;
+    cursor: pointer;
+
+    &.active {
+      background-color: #1bbfc1;
+      color: #ffffff;
+    }
   }
 }
 

--- a/src/Page/WorkArrangement/css/ViewMyWork.scss
+++ b/src/Page/WorkArrangement/css/ViewMyWork.scss
@@ -94,6 +94,10 @@
         line-height: 22px;
 
         .vmw-input-group {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
           #input-styled {
             border: 1px solid #E5E5EC;
             width: 22px;
@@ -175,5 +179,35 @@
     line-height: 28px;
     letter-spacing: -0.025em;
     margin-bottom: 120px;
+  }
+}
+
+input[type="radio"] {
+  appearance: none; // 기본 브라우저 스타일 제거
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 22px;
+  height: 22px;
+  border: 2px solid #E5E5EC;
+  background-color: white;
+  position: relative;
+  cursor: pointer;
+  margin: 0 0 0 8px;
+
+  &:checked {
+    background-color: #204598;
+    border-color: #204598;
+
+    &::after {
+      font-family: 'Pretendard';
+      content: '✓'; // 체크 표시
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%); // 중앙 정렬
+      color: white;
+      font-size: 16px;
+      font-weight: bold;
+    }
   }
 }

--- a/src/Page/WorkArrangement/css/ViewMyWorkResult.scss
+++ b/src/Page/WorkArrangement/css/ViewMyWorkResult.scss
@@ -38,6 +38,7 @@
       line-height: 28px;
       letter-spacing: -0.025em;
       padding: 16px;
+      cursor: pointer;
     }
   }
 }

--- a/src/Page/WorkArrangement/css/WorkArrangementResult.scss
+++ b/src/Page/WorkArrangement/css/WorkArrangementResult.scss
@@ -60,6 +60,7 @@
     .wa-description {
       display: flex;
       flex-direction: column;
+      color: #666666;
 
       /* background-color: yellowgreen; */
       // margin: 0 111px 46px 40px;

--- a/src/Page/WorkArrangement/css/WorkArrangementResult.scss
+++ b/src/Page/WorkArrangement/css/WorkArrangementResult.scss
@@ -72,7 +72,26 @@
       display: flex;
       flex-direction: column;
       width: 450px;
-
+      
+      .wa-true-options,
+      .wa-false-options {
+        display: flex;
+        flex-wrap: wrap;
+      }
+    
+      .waOption.more {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 45px;
+        height: 45px;
+        background-color: #f1f1f5;
+        color: #999999;
+        border-radius: 50%;
+        font-size: 20px;
+        font-weight: bold;
+      }
+      
       /* background-color: tomato; */
       /* border: 1px solid black; */
       // margin-left: 111px;

--- a/src/Page/WorkArrangement/css/WorkArrangementResult.scss
+++ b/src/Page/WorkArrangement/css/WorkArrangementResult.scss
@@ -89,28 +89,41 @@
           margin-bottom: 12px;
         }
 
-        #wa-option {
+        .wa-list {
           font-size: 12px;
           display: flex;
-          justify-content: center;
-          align-items: center;
-          border-radius: 50px;
-          width: 95px;
-          height: 45px;
-          margin-right: 12px;
-          margin-bottom: 24px;
+          flex-direction: column;
 
-          &.true {
-            background-color: #204598;
-            color: white;
+          .wa-row {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 24px;
+          
+            .check {
+              display: flex;
+              background-color: #204598;
+              color: white;
+              justify-content: center;
+              align-items: center;
+              border-radius: 50px;
+              width: 95px;
+              height: 45px;
+              margin-right: 12px;    
+            }
+    
+            .uncheck {
+              display: flex;
+              background-color: #f1f1f5;
+              color: #999999;
+              justify-content: center;
+              align-items: center;
+              border-radius: 50px;
+              width: 95px;
+              height: 45px;
+              margin-right: 12px;
+            }
           }
-        
-          &.false {
-            background-color: #f1f1f5;
-            color: #999999;
           }
-        }
-
       }
     }
   }

--- a/src/Page/WorkArrangement/css/WorkArrangementResult.scss
+++ b/src/Page/WorkArrangement/css/WorkArrangementResult.scss
@@ -90,9 +90,7 @@
         }
 
         #wa-option {
-          background-color: #204598;
           font-size: 12px;
-          color: white;
           display: flex;
           justify-content: center;
           align-items: center;
@@ -101,6 +99,16 @@
           height: 45px;
           margin-right: 12px;
           margin-bottom: 24px;
+
+          &.true {
+            background-color: #204598;
+            color: white;
+          }
+        
+          &.false {
+            background-color: #f1f1f5;
+            color: #999999;
+          }
         }
 
       }

--- a/src/Page/WorkArrangement/css/WorkArrangementResult.scss
+++ b/src/Page/WorkArrangement/css/WorkArrangementResult.scss
@@ -73,25 +73,6 @@
       flex-direction: column;
       width: 450px;
       
-      .wa-true-options,
-      .wa-false-options {
-        display: flex;
-        flex-wrap: wrap;
-      }
-    
-      .waOption.more {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 45px;
-        height: 45px;
-        background-color: #f1f1f5;
-        color: #999999;
-        border-radius: 50%;
-        font-size: 20px;
-        font-weight: bold;
-      }
-      
       /* background-color: tomato; */
       /* border: 1px solid black; */
       // margin-left: 111px;

--- a/src/Page/WorkArrangement/data/viewMyWork.data.js
+++ b/src/Page/WorkArrangement/data/viewMyWork.data.js
@@ -1,7 +1,7 @@
 const user = '코카콜라';
 const data = [
   {
-    id: '0',
+    id: 'hourPay',
     option: `${user}님의 시급은 얼마입니까?`,
     display: 'none',
     type: 'input',
@@ -10,7 +10,7 @@ const data = [
     warning: '숫자를 입력해 주세요',
   },
   {
-    id: '1',
+    id: 'weekWork',
     option: '한 주 동안 근로 시간은 몇 시간 입니까?',
     display: 'none',
     type: 'input',
@@ -19,14 +19,14 @@ const data = [
     warning: '숫자를 입력해 주세요',
   },
   {
-    id: '2',
+    id: 'overFive',
     option: '상시 5인 이상 사업장입니까?',
     display: 'none',
     type: 'binary',
     warning: '두 체크 박스 중 하나를 선택해 주세요',
   },
   {
-    id: '3',
+    id: 'overtimeWork',
     option: '한 주 동안 연장 근로시간은 몇 시간  입니까?',
     display: 'flex',
     description: '주 연장 근로 시간 (1일 8시간, 1주 40시간 초과한 시간)',
@@ -36,7 +36,7 @@ const data = [
     warning: '숫자를 입력해 주세요',
   },
   {
-    id: '4',
+    id: 'nightWork',
     option: '한 주 동안 야간 근로시간이 몇 시간 입니까?',
     display: 'flex',
     description: '야간 근로 시간 (오후 10시부터 명일 오전 6시까지 근무한 시간)',
@@ -46,7 +46,7 @@ const data = [
     warning: '숫자를 입력해 주세요',
   },
   {
-    id: '5',
+    id: 'holidayWork',
     option: '취업규칙 등에서 정한 약정휴일에 근무하는 시간은?',
     display: 'none',
     type: 'input',
@@ -55,7 +55,7 @@ const data = [
     warning: '숫자를 입력해 주세요',
   },
   {
-    id: '6',
+    id: 'tax',
     option: '어떤 세금이 적용되나요?',
     display: 'none',
     type: 'multi',

--- a/src/Page/WorkArrangement/function/generateResultContent.js
+++ b/src/Page/WorkArrangement/function/generateResultContent.js
@@ -1,0 +1,54 @@
+const generateResultContent = data => {
+  const content = [];
+
+  // 1. 추가 수당 여부 메시지
+  content.push(
+    data.over_five
+      ? '상시 5인 이상 사업장에서 근무하시므로 추가적인 가산 수당이 발생합니다.'
+      : '상시 5인 미만 사업장에서 근무하셨으므로 추가적인 가산 수당이 발생하지 않습니다.',
+  );
+
+  // 2. 주휴수당 메시지
+  content.push(
+    data.week_pay
+      ? `주 근로 시간이 ${data.week_work}시간으로 주휴수당이 발생합니다.`
+      : `주 근로 시간이 ${data.week_work}시간으로 주휴수당이 발생하지 않습니다.`,
+  );
+
+  // 3. 야간 근로 수당 메시지
+  content.push(
+    data.night_pay
+      ? `한 주 동안 야간 근로시간이 ${data.night_work} 시간이므로 야간근로수당 ${data.night_money}원이 발생합니다.`
+      : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
+  );
+
+  // 4. 연장 근로 수당 메시지
+  content.push(
+    data.overtime_pay
+      ? `한 주 동안 연장 근로시간이 ${data.overtime_work} 시간이므로 야간근로수당 ${data.overtime_money}원이 발생합니다.`
+      : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
+  );
+
+  // 5. 휴일 근로 수당 메시지
+  content.push(
+    data.holiday_pay
+      ? `취업 규칙 등에서 정한 약정 휴일에 ${data.overtime_work} 시간 근무하므로 휴일근로수당 ${data.overtime_money}원이 발생합니다.`
+      : '5인 미만 사업장에서 근무하시기에 휴일근로수당은 발생하지 않습니다.',
+  );
+
+  // 6. 4대보험 메시지
+  content.push(
+    data.major_insurance ? '4대보험 9.32%가 적용됩니다.' : '',
+    data.income_tax ? '소득세 3.3%가 적용됩니다.' : '',
+  );
+
+  // 7. 총 급여 메시지
+  content.push(
+    `따라서, ${data.nickname || ''}님의 월급은 ${data.total_pay.toLocaleString()}원 입니다.`,
+  );
+
+  return content;
+};
+
+// Export the function for use in other files
+export default generateResultContent;

--- a/src/Page/WorkArrangement/function/generateResultContent.js
+++ b/src/Page/WorkArrangement/function/generateResultContent.js
@@ -4,7 +4,7 @@ const generateResultContent = isData => {
     content: {
       overFiveMessage: isData.over_five
         ? '상시 5인 이상 사업장에서 근무하시므로 추가적인 가산 수당이 발생합니다.'
-        : '상시 5인 미만 사업장에서 근무하셨으므로 추가적인 가산 수당이 발생하지 않습니다.',
+        : '상시 5인 미만 사업장에서 근무하시므로 추가적인 가산 수당이 발생하지 않습니다.',
 
       weekPayMessage: isData.week_pay
         ? `주 근로 시간이 ${isData.week_work}시간으로 주휴수당이 발생합니다.`

--- a/src/Page/WorkArrangement/function/generateResultContent.js
+++ b/src/Page/WorkArrangement/function/generateResultContent.js
@@ -12,11 +12,11 @@ const generateResultContent = isData => {
 
       nightPayMessage: isData.night_pay
         ? `한 주 동안 야간 근로시간이 ${isData.night_work} 시간이므로 야간근로수당 ${isData.night_money}원이 발생합니다.`
-        : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
+        : `5인 미만 사업장에서 근무하시기에 야간근로수당은 발생하지 않습니다.`,
 
       overtimePayMessage: isData.overtime_pay
         ? `한 주 동안 연장 근로시간이 ${isData.overtime_work} 시간이므로 연장근로수당 ${isData.overtime_money}원이 발생합니다.`
-        : `5인 미만 사업장에서 근무하시기에 연장 근로수당은 발생하지 않습니다.`,
+        : `5인 미만 사업장에서 근무하시기에 연장근로수당은 발생하지 않습니다.`,
 
       holidayPayMessage: isData.holiday_pay
         ? `취업 규칙 등에서 정한 약정 휴일에 ${isData.holiday_work} 시간 근무하므로 휴일근로수당 ${isData.holiday_money}원이 발생합니다.`

--- a/src/Page/WorkArrangement/function/generateResultContent.js
+++ b/src/Page/WorkArrangement/function/generateResultContent.js
@@ -1,54 +1,41 @@
-const generateResultContent = data => {
-  const content = [];
+const user = '코카콜라';
+const generateResultContent = isData => {
+  const data = {
+    content: {
+      overFiveMessage: isData.over_five
+        ? '상시 5인 이상 사업장에서 근무하시므로 추가적인 가산 수당이 발생합니다.'
+        : '상시 5인 미만 사업장에서 근무하셨으므로 추가적인 가산 수당이 발생하지 않습니다.',
 
-  // 1. 추가 수당 여부 메시지
-  content.push(
-    data.over_five
-      ? '상시 5인 이상 사업장에서 근무하시므로 추가적인 가산 수당이 발생합니다.'
-      : '상시 5인 미만 사업장에서 근무하셨으므로 추가적인 가산 수당이 발생하지 않습니다.',
-  );
+      weekPayMessage: isData.week_pay
+        ? `주 근로 시간이 ${isData.week_work}시간으로 주휴수당이 발생합니다.`
+        : `주 근로 시간이 ${isData.week_work}시간으로 주휴수당이 발생하지 않습니다.`,
 
-  // 2. 주휴수당 메시지
-  content.push(
-    data.week_pay
-      ? `주 근로 시간이 ${data.week_work}시간으로 주휴수당이 발생합니다.`
-      : `주 근로 시간이 ${data.week_work}시간으로 주휴수당이 발생하지 않습니다.`,
-  );
+      nightPayMessage: isData.night_pay
+        ? `한 주 동안 야간 근로시간이 ${isData.night_work} 시간이므로 야간근로수당 ${isData.night_money}원이 발생합니다.`
+        : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
 
-  // 3. 야간 근로 수당 메시지
-  content.push(
-    data.night_pay
-      ? `한 주 동안 야간 근로시간이 ${data.night_work} 시간이므로 야간근로수당 ${data.night_money}원이 발생합니다.`
-      : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
-  );
+      overtimePayMessage: isData.overtime_pay
+        ? `한 주 동안 연장 근로시간이 ${isData.overtime_work} 시간이므로 연장근로수당 ${isData.overtime_money}원이 발생합니다.`
+        : `5인 미만 사업장에서 근무하시기에 연장 근로수당은 발생하지 않습니다.`,
 
-  // 4. 연장 근로 수당 메시지
-  content.push(
-    data.overtime_pay
-      ? `한 주 동안 연장 근로시간이 ${data.overtime_work} 시간이므로 야간근로수당 ${data.overtime_money}원이 발생합니다.`
-      : `5인 미만 사업장에서 근무하시기에 야간 근로수당은 발생하지 않습니다.`,
-  );
+      holidayPayMessage: isData.holiday_pay
+        ? `취업 규칙 등에서 정한 약정 휴일에 ${isData.holiday_work} 시간 근무하므로 휴일근로수당 ${isData.holiday_money}원이 발생합니다.`
+        : '5인 미만 사업장에서 근무하시기에 휴일근로수당은 발생하지 않습니다.',
 
-  // 5. 휴일 근로 수당 메시지
-  content.push(
-    data.holiday_pay
-      ? `취업 규칙 등에서 정한 약정 휴일에 ${data.overtime_work} 시간 근무하므로 휴일근로수당 ${data.overtime_money}원이 발생합니다.`
-      : '5인 미만 사업장에서 근무하시기에 휴일근로수당은 발생하지 않습니다.',
-  );
+      insuranceMessage: isData.major_insurance
+        ? '4대보험 9.32%가 적용됩니다.'
+        : '',
 
-  // 6. 4대보험 메시지
-  content.push(
-    data.major_insurance ? '4대보험 9.32%가 적용됩니다.' : '',
-    data.income_tax ? '소득세 3.3%가 적용됩니다.' : '',
-  );
+      incomeTaxMessage: isData.income_tax ? '소득세 3.3%가 적용됩니다.' : '',
 
-  // 7. 총 급여 메시지
-  content.push(
-    `따라서, ${data.nickname || ''}님의 월급은 ${data.total_pay.toLocaleString()}원 입니다.`,
-  );
+      totalPayMessage: `따라서, ${user}님의 월급은 ${isData.total_pay}원 입니다.`,
+    },
+  };
 
-  return content;
+  return {
+    ...isData,
+    data,
+  };
 };
 
-// Export the function for use in other files
 export default generateResultContent;

--- a/src/Page/WorkArrangement/function/optionColor.js
+++ b/src/Page/WorkArrangement/function/optionColor.js
@@ -1,0 +1,5 @@
+const optionColor = isTrue => {
+  return isTrue ? 'true' : 'false';
+};
+
+export default optionColor;

--- a/src/Page/WorkArrangement/function/optionColor.js
+++ b/src/Page/WorkArrangement/function/optionColor.js
@@ -1,5 +1,0 @@
-const optionColor = isTrue => {
-  return isTrue ? 'true' : 'false';
-};
-
-export default optionColor;


### PR DESCRIPTION
## #️⃣ Issue Number
- close #71 

### ✏️Task
- [x] 내 근로 정리 (WorkArrangement) 페이지 컴포넌트를 분리한다.
- [x] 내 근로 정리 (WorkArrangement) 페이지 API를 연결한다.

## ✏️Tasks Description
- 작업하면서 크게 어려운 부분은 없었다. 원래 작성되어있던 useFetchAPI와 로직을 가져와서 사용하기만 하면 돼서 수월하게 작업할 수 있었다. 따라서 아래에서 설명할 내용들은 간략한 코드 정리와 새로 컴포넌트가 생성되는 등 알아둬야 할 부분을 정리해뒀다. 우선 연결한 API는 다음과 같다.
  ![image](https://github.com/user-attachments/assets/f83e9190-ba80-4123-a442-c48e3d7c20b7)
  - WorkArrangement 페이지에서 다른 근로 결과지들을 `공유하기 된 결과지만 조회` **GET**으로 받아서 WorkArrangementResult 컴포넌트에 map으로 넘겨줬다. 이때 slice를 사용해서 3개만 보이게 해줬다. 그리고 목록을 클릭했을 때 넘어가는 새로운 페이지를 생성했다. 페이지 경로는 **/WorkArrangement/List** 이다. 
  - WorkArrangementResult 컴포넌트를 **상세보기**를 클릭했을 때 넘어가는 결과지 세부 조회 화면, 내 계약서 검토 설문지 입력 후 넘어가는 **내 근로 현황 결과지** 두 군데서 사용하고 있었다. 상세보기를 클릭했을때는 worksheet id 값을 전달해줘야하고 내 근로 현황 결과지 페이지에서는 이전에 작성했던 설문 내용을 POST한 뒤 response 받은 값을 표시해 준 후, 저장하기를 누르면 POST로 결과지가 저장되어야 한다. 두 페이지에서의 역할이 다르다고 판단되어 우선 컴포넌트를 분리해서 작업하였다. 두 페이지의 경로는 app.jsx에 다음과 같이 지정되어 있다.
    ```
     <Route
        path="/ViewMyWorkResult/:worksheetId"
        element={<ViewMyWorkResult />}
      />
      <Route
        path="/ViewMyWorkResult"
        element={<ViewMyWorkResultCalculate />}
      />
     ```
  - 따라서 vmwrResult 컴포넌트는 worksheetid 값이 있을 때와 없을 때 둘 다 작동할 수 있게 작성이 되어야한다. 따라서 props로 worksheetId와 postData, onResultValues(postData의 content를 가공해서 부모로 넘겨주는 함수)를 작성하였다. 사실 이 부분을 고민하는데 가장 오래 걸렸다. vmwrResult 컴포넌트를 두 개로 분리해야할지도 생각해봤지만 vmwrResult는 Globla로 분리되어서 사용되는 컴포넌트이므로 공용으로 사용할 수 있게 하나로 두고 여러 방향으로 사용하는 방법이 맞을 것 같아 합쳐서 작업했다.
 
>사실 작업을 마무리하고 PR 작성을 두 번째 하는 중이다. 처음 작성했던 PR은 상세하게 변경된 코드를 하나하나 설명하고자 하였으나 어렵거나 중요한 부분 없이 내용만 길어져 이 PR의 핵심을 가리는 것 같아서 새롭게 생성된 컴포넌트나 페이지, 크게 고민한 부분들 위주로 다시 작성하였다. 이번 작업을 하면서 컴포넌트 분리에 대한 고민을 다양하게 해봤다. 어떤 것이 정답인지는 몰라도 해결해 나가는 과정에 집중하며 재미있게 작업했던 것 같다. 이번 issue에서 한 가지 아쉬운 점은 학업으로 인해 기간이 딜레이 됐다는 것이다.
 
### 🗓Next Task
- 

